### PR TITLE
PR #23 - Backporting security features from 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ nibtodo.txt
 send/
 nibchanges.txt
 .build/
+.depend

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC      = gcc
 PROF    = -Wall -O -g -pg -ggdb
 OBJDIR	= obj
 VPATH   = .:obj
-LIBS = -lpthread -lz -lm -lrt -lssl -lcrypto -ldl -lcrypt -lquickmail
+LIBS = -lpthread -lz -lm -lrt -lssl -lcrypto -ldl -lcrypt -lquickmail  -lcotp -lqrencode -lpng
 C_FLAGS = $(PROF) -fcommon -DMALLOC_STDLIB -fstack-protector  -m64 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fno-strict-aliasing -fwrapv -fPIC -fabi-version=2 -fno-omit-frame-pointer -DVERSION=\"$(GIT_VERSION)\" -DBUILD_DATE=\"$(CUR_BUILD_DATE)\" -DBUILD_NUMBER=\"$(CUR_BUILD_NUMBER)\" -DCOMMIT=\"$(GIT_URL)\"
 L_FLAGS =  $(PROF) $(LIBS)
 EXE	= sent
@@ -21,6 +21,7 @@ DIFF_TXT = diff_$(VERSION1)_$(VERSION2).txt
 DIFF_C = $(patsubst $(PATH1)/%.c,%_c.diff,$(wildcard $(PATH1)/*.c)) $(patsubst $(PATH1)/%.h,%_h.diff,$(wildcard $(PATH1)/*.h))
 
 C_FILES = \
+	account/otp.c \
 	act_comm.c \
 	act_enter.c \
 	act_info.c \
@@ -121,12 +122,14 @@ C_FILES = \
 	stats.c \
 	string.c \
 	tables.c \
+	tls.c \
 	treasuremap.c \
 	update.c \
 	weather.c \
 	wilds.c \
 
 O_FILES = \
+	$(OBJDIR)/account/otp.o \
 	$(OBJDIR)/act_comm.o \
 	$(OBJDIR)/act_enter.o \
 	$(OBJDIR)/act_info.o \
@@ -219,7 +222,6 @@ O_FILES = \
 	$(OBJDIR)/script_tpcmds.o \
 	$(OBJDIR)/script_vars.o \
 	$(OBJDIR)/scripts.o \
-	$(OBJDIR)/sha256.o \
 	$(OBJDIR)/shoot.o \
 	$(OBJDIR)/skills.o \
 	$(OBJDIR)/social.o \
@@ -228,6 +230,7 @@ O_FILES = \
 	$(OBJDIR)/stats.o \
 	$(OBJDIR)/string.o \
 	$(OBJDIR)/tables.o \
+	$(OBJDIR)/tls.o \
 	$(OBJDIR)/treasuremap.o \
 	$(OBJDIR)/update.o \
 	$(OBJDIR)/weather.o \
@@ -254,7 +257,8 @@ install: all
 
 objdir:
 	-mkdir obj
-	-chmod 775 obj
+	-mkdir obj/account
+	-chmod 775 obj obj/account
 
 $(EXE): $(O_FILES) $(BUILD_NUMBER_FILE)
 	rm -f $(EXE)

--- a/account/otp.c
+++ b/account/otp.c
@@ -1,0 +1,235 @@
+ /***************************************************************************
+ *  Original Diku Mud copyright (C) 1990, 1991 by Sebastian Hammer,        *
+ *  Michael Seifert, Hans Henrik St{rfeldt, Tom Madsen, and Katja Nyboe.   *
+ *                                                                         *
+ *  Merc Diku Mud improvments copyright (C) 1992, 1993 by Michael          *
+ *  Chastain, Michael Quan, and Mitchell Tse.                              *
+ *                                                                         *
+ *  In order to use any part of this Merc Diku Mud, you must comply with   *
+ *  both the original Diku license in 'license.doc' as well the Merc       *
+ *  license in 'license.txt'.  In particular, you may not remove either of *
+ *  these copyright notices.                                               *
+ *                                                                         *
+ *  Thanks to abaddon for proof-reading our comm.c and pointing out bugs.  *
+ *  Any remaining bugs are, of course, our work, not his.  :)              *
+ *                                                                         *
+ *  Much time and thought has gone into this software and you are          *
+ *  benefitting.  We hope that you share your changes too.  What goes      *
+ *  around, comes around.                                                  *
+ ***************************************************************************/
+
+/***************************************************************************
+*	ROM 2.4 is copyright 1993-1998 Russ Taylor			   *
+*	ROM has been brought to you by the ROM consortium		   *
+*	    Russ Taylor (rtaylor@hypercube.org)				   *
+*	    Gabrielle Taylor (gtaylor@hypercube.org)			   *
+*	    Brian Moore (zump@rom.org)					   *
+*	By using this code, you have agreed to follow the terms of the	   *
+*	ROM license, in the file Rom24/doc/rom.license			   *
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *    Scripting engine rebuilt by Michael Kurtz (Nibelung)                 *
+ *    Used with permission.                                                *
+ *                                                                         *
+ **************************************************************************/
+
+/*
+ * This file contains all of the OS-dependent stuff:
+ *   startup, signals, BSD sockets for tcp/ip, i/o, timing.
+ *
+ * The data flow for input is:
+ *    Game_loop ---> Read_from_descriptor ---> Read
+ *    Game_loop ---> Read_from_buffer
+ *
+ * The data flow for output is:
+ *    Game_loop ---> Process_Output ---> Write_to_descriptor -> Write
+ *
+ * The OS-dependent functions are Read_from_descriptor and Write_to_descriptor.
+ * -- Furey  26 Jan 1993
+ */
+
+#include <sys/types.h>
+#include <sys/time.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <time.h>
+#include <zlib.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <libpng/png.h>
+/* VIZZWILDS - support for plogf() and printf_to_char() functions*/
+#include <stdarg.h>
+#include <cotp.h>
+#include <qrencode.h>
+
+#include "../strings.h"
+#include "../merc.h"
+#include "../interp.h"
+#include "../recycle.h"
+#include "../scripts.h"
+#include "../tables.h"
+#include "../wilds.h"
+#include "../protocol.h"
+ 
+void do_keygen(CHAR_DATA *ch, char *argument)
+{
+    char buf[MSL];
+    if (argument[0] == '\0')
+    {
+        send_to_char("Syntax: keygen\n\r", ch);
+        return;
+    }
+
+    if (IS_NPC(ch))
+    {
+        send_to_char("NPCs cannot use MFA.\n\r", ch);
+        return;
+    }
+
+    if (!strcmp(argument, "clear"))
+    {
+        if (IS_NULLSTR(ch->pcdata->mfa_key))
+        {
+            send_to_char("You do not have an MFA key to clear.\n\r", ch);
+            return;
+        }
+        free_string(ch->pcdata->mfa_key);
+        ch->pcdata->mfa_key = str_dup("");
+        send_to_char("Your MFA key has been cleared.\n\r", ch);
+        return;
+    }
+    else if (!strcmp(argument, "generate"))
+    {
+        if (IS_NULLSTR(ch->pcdata->mfa_key))
+        {
+            char random_string[MIL];
+            char otp_url[MIL];
+            char filename[256];
+            generate_reset_code(random_string, 16);
+            sprintf(buf, "%s", random_string);
+            generate_key(ch, random_string);
+            send_to_char("Your MFA key has been generated. Please save this key in a safe place.\n\r", ch);
+            send_to_char("You will need this key to authenticate your account with MFA.\n\r", ch);
+            send_to_char("Your key is: ", ch);
+            send_to_char(ch->pcdata->mfa_key, ch);
+            send_to_char("\n\r", ch);
+
+            sprintf(otp_url, "otpauth://totp/Sentience:%s?secret=%s&Issuer=SentienceMUD&digits=6", ch->name, ch->pcdata->mfa_key);
+            send_to_char("You can add this key to your MFA app by scanning the following QR code:\n\r", ch);
+
+            QRcode *qrcode = QRcode_encodeString(otp_url, 0, QR_ECLEVEL_L, QR_MODE_8, 1);
+            if (qrcode) {
+                ch->pcdata->qr_code_expiration = time(NULL) + 10 * 60; // 10 minutes
+                for (int i = -1; i <= qrcode->width; i++) {
+                    for (int j = -1; j <= qrcode->width; j++) {
+                        if (i >= 0 && i < qrcode->width && j >= 0 && j < qrcode->width && qrcode->data[i * qrcode->width + j] & 1) {
+                            send_to_char("\033[40m  \033[0m", ch);
+                        } else {
+                        send_to_char("\033[47m  \033[0m", ch);
+                        }
+                    }
+                    send_to_char("\n\r", ch);
+                }
+                sprintf(filename, "/tmp/%s-qrcode.png", ch->name);
+                save_qr_code_as_png(qrcode, filename, 5);
+
+                char email_body[1024];
+                sprintf(email_body, "Dear %s,\n\nYour MFA key has been generated. Please save this key in a safe place.\n\nYou will need this key to authenticate your account with MFA.\n\nYour key is: %s\n\nYou can add this key to your MFA app by scanning the following QR code:\n\n", ch->name, ch->pcdata->mfa_key);
+                send_email_async(ch, ch->pcdata->email, "Sentience MUD MFA Key", email_body, filename, "image/png");
+                QRcode_free(qrcode);
+            }
+            else {
+                send_to_char("Error generating QR code.\n\r", ch);
+            }
+        }
+        else
+        {
+            send_to_char("You already have an MFA key. If you would like to generate a new key, please run 'keygen clear'.\n\r", ch);
+        }
+    }
+    else if (!str_prefix(argument, "confirm"))
+    {
+        if (IS_NULLSTR(ch->pcdata->mfa_key) && ch->pcdata->qr_code_expiration == 0)
+        {
+            send_to_char("You do not have an MFA key to validate.\n\r", ch);
+            return;
+        }
+        // Check if the QR code has expired
+        if (time(NULL) > ch->pcdata->qr_code_expiration) {
+            send_to_char("The QR code has expired. Please generate a new one.\n\r", ch);
+            free_string(ch->pcdata->mfa_key);
+            ch->pcdata->mfa_key = str_dup("");
+            ch->pcdata->qr_code_expiration = 0;
+
+            return;
+        }
+
+        // Prompt the user to enter the MFA code
+        send_to_char("Please enter the code from your MFA app to authenticate your account.\n\r", ch);
+        ch->pcdata->mfa_question = true;
+        return;
+
+        // Wait for the user to enter the code (this part depends on your input handling system)
+        // For example, you might have a separate function to handle user input
+        // Here, we'll assume the code is provided in the `argument` variable
+    }
+    else
+    {
+        send_to_char("Syntax: keygen <generate|clear|confirm>\n\r", ch);
+        return;
+    }
+}
+ 
+ void generate_key(CHAR_DATA *ch, char *key)
+ {
+ //    char random_string[MIL];
+ //    generate_reset_code(random_string, 64);
+     cotp_error_t cotp_err;
+ 
+     char *secret_key = base32_encode((uchar *)key, strlen(key)+1, &cotp_err);
+     if (!IS_NULLSTR(ch->pcdata->mfa_key))
+     {
+         free_string(ch->pcdata->mfa_key);
+         ch->pcdata->mfa_key = str_dup("");
+     }
+     ch->pcdata->mfa_key = str_dup(secret_key);
+     free_string(secret_key);
+ }
+ 
+ bool check_mfa(CHAR_DATA *ch, char *argument)
+ {
+     char *provided_code = argument;
+     cotp_error_t err;
+     char buf[MSL];
+ 
+     char current_totp[MIL];
+     char previous_totp[MIL];
+     current_totp[0] = '\0';
+     previous_totp[0] = '\0';
+ 
+     time_t current_time = time(NULL);
+ 
+ 
+     
+     sprintf(current_totp, "%s", get_totp_at(ch->pcdata->mfa_key, current_time, 6, 30, SHA1, &err));
+     sprintf(previous_totp, "%s", get_totp_at(ch->pcdata->mfa_key, current_time - 30, 6, 30, SHA1, &err));
+ 
+     if (!str_cmp(provided_code, current_totp) || !str_cmp(provided_code, previous_totp))
+     {
+         sprintf(buf, "You have successfully authenticated your account with MFA.\n\r");
+         return true;
+     }
+     else
+     {
+         sprintf(buf, "The code you provided is incorrect. Please try again.\n\r");
+         send_to_char(buf,ch);
+         return false;
+     }
+     return false;
+ }

--- a/account/otp.c
+++ b/account/otp.c
@@ -80,11 +80,6 @@
 void do_keygen(CHAR_DATA *ch, char *argument)
 {
     char buf[MSL];
-    if (argument[0] == '\0')
-    {
-        send_to_char("Syntax: keygen\n\r", ch);
-        return;
-    }
 
     if (IS_NPC(ch))
     {
@@ -181,7 +176,7 @@ void do_keygen(CHAR_DATA *ch, char *argument)
     }
     else
     {
-        send_to_char("Syntax: keygen <generate|clear|confirm>\n\r", ch);
+        send_to_char("Syntax: mfa <generate|clear|confirm>\n\r", ch);
         return;
     }
 }

--- a/act_info.c
+++ b/act_info.c
@@ -40,6 +40,8 @@
 #include <ctype.h>
 #include <time.h>
 #include <math.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
 #include "strings.h"
 #include "merc.h"
 #include "interp.h"
@@ -50,7 +52,6 @@
 /* VIZZWILDS - Include wilds.h header */
 #include "wilds.h"
 #include "scripts.h"
-#include "sha256.h"
 
 
 bool can_see_imm(CHAR_DATA *ch, CHAR_DATA *victim);
@@ -1347,7 +1348,7 @@ void do_socials(CHAR_DATA * ch, char *argument)
     col = 0;
     for (iSocial = 0; social_table[iSocial].name[0] != '\0'; iSocial++)
     {
-	sprintf(buf, "%-12s", social_table[iSocial].name);
+	sprintf(buf, "%-12.12s", social_table[iSocial].name);
 	send_to_char(buf, ch);
 	if (++col % 6 == 0)
 	    send_to_char("\n\r", ch);

--- a/act_info2.c
+++ b/act_info2.c
@@ -83,11 +83,11 @@ void list_attachment_callback (quickmail mailobj, const char* filename, quickmai
 void do_testemail (CHAR_DATA *ch, char *argument)
 {
 
-  extern GLOBAL_DATA gconfig;
+  extern GAME_SETTINGS_DATA game_settings;
 
   char buf[MAX_STRING_LENGTH];
 
-  if (IS_NULLSTR(gconfig.email_host) || gconfig.email_port == 0 || IS_NULLSTR(gconfig.email_username) || IS_NULLSTR(gconfig.email_password) || IS_NULLSTR(gconfig.email_from_addr))
+  if (IS_NULLSTR(game_settings.email_host) || game_settings.email_port == 0 || IS_NULLSTR(game_settings.email_username) || IS_NULLSTR(game_settings.email_password) || IS_NULLSTR(game_settings.email_from_addr))
   {
     send_to_char("One or more email configuration items is missing.\n\r",ch);
     sprintf(buf, "Host: %s\n\rPort: %d\n\rUsername: %s\n\rPassword: %s\n\rFrom Address: %s\n\r", gconfig.email_host, gconfig.email_port, gconfig.email_username, gconfig.email_password, gconfig.email_from_addr);
@@ -104,7 +104,7 @@ void do_testemail (CHAR_DATA *ch, char *argument)
   else
     sprintf(subjline, "Test Email");
 
-  quickmail mailobj = quickmail_create(gconfig.email_from_name, gconfig.email_from_addr, subjline);
+  quickmail mailobj = quickmail_create(game_settings.email_from_name, game_settings.email_from_addr, subjline);
 
   quickmail_add_to(mailobj, ch->pcdata->email);
 #ifdef TO
@@ -146,7 +146,7 @@ void do_testemail (CHAR_DATA *ch, char *argument)
 
   const char* errmsg;
   //quickmail_set_debug_log(mailobj, stderr);
-  if ((errmsg = quickmail_send(mailobj, gconfig.email_host, gconfig.email_port, gconfig.email_username, gconfig.email_password)) != NULL)
+  if ((errmsg = quickmail_send(mailobj, game_settings.email_host, game_settings.email_port, game_settings.email_username, game_settings.email_password)) != NULL)
     fprintf(stderr, "Error sending e-mail: %s\n", errmsg);
   quickmail_destroy(mailobj);
   quickmail_cleanup();

--- a/act_wiz.c
+++ b/act_wiz.c
@@ -226,6 +226,333 @@ int gconfig_read (void)
     } /* end for */
 }
 
+int game_settings_read (void)
+{
+    FILE *fp;
+    bool fMatch;
+    char *word;
+    char buf[MIL];
+
+
+    log_string("Loading configuration settings from game_settings.dat...");
+
+    fp = fopen(GAME_SETTINGS_FILE,"r");
+    if (!fp)
+    {
+        bug("act_wiz.c, gamesettings_read(): Unable to open game_settings.dat file for reading.",0);
+        return(1); /* Failure*/
+    }
+
+	/* Basic settings */
+
+	game_settings.game_name = "";
+	game_settings.login_string = "";
+	game_settings.server_description = "";
+	game_settings.testport = false;
+	game_settings.wizlock = false;
+	game_settings.new_acct_lock = false;
+	game_settings.new_char_lock = false;
+	game_settings.wizlock_msg = "";
+	game_settings.new_acct_lock_msg = "";
+	game_settings.new_char_lock_msg = "";
+	game_settings.logall = false;
+
+	/* Auth */
+	game_settings.require_uniq_pass_staff = false;
+	game_settings.max_login_attempts = 0;
+
+	/* 2FA */
+	game_settings.require_2fa_all = false;
+	game_settings.require_2fa_staff = false;
+	
+	/* Multiplaying */
+	game_settings.allow_multiplay_acct_all = false;
+	game_settings.allow_multiplay_acct_staff = false;
+	game_settings.allow_multiplay_host_all = false;
+	game_settings.allow_multiplay_host_staff = false;
+
+	/* Timers */
+	game_settings.idle_time = 0;
+	game_settings.idle_disconnect_time = 0;
+
+	/* Misc Maximums */
+	game_settings.max_alias = 0;
+	game_settings.max_characters = 0;
+	game_settings.max_churches = 0;
+	game_settings.max_logfile_size = 0;
+
+	/* Email */
+	game_settings.enable_email = false;
+	game_settings.require_email_verification = false;
+	game_settings.email_port = 0;
+	game_settings.email_username = "";
+	game_settings.email_host = "";
+	game_settings.email_password = "";
+	game_settings.email_from_addr = "";
+	game_settings.email_from_name = "";
+
+	/* Quests */
+	game_settings.max_quest_allowance = 0;
+	game_settings.inc_quests = 0;		// Per day
+	game_settings.max_quests = 0;
+
+	/* Protocols and Ports*/
+	game_settings.enable_telnet = false;
+	game_settings.telnet_port = 0;
+	game_settings.enable_tls = false;
+	game_settings.tls_port = 0;
+	game_settings.ssl_cert_path = "";
+	game_settings.ssl_key_path = "";
+
+	game_settings.enable_insecure_warning = false;
+	game_settings.insecure_warning_msg = "";
+
+	/* MSSP */
+	game_settings.mssp_players = 0;
+	game_settings.mssp_uptime = 0;
+	game_settings.mssp_crawl_delay = 0;
+	game_settings.mssp_hostname = "";
+	game_settings.mssp_port = 0;
+	game_settings.mssp_tls_port = 0;
+	game_settings.mssp_codebase = "";
+	game_settings.mssp_contact = "";
+	game_settings.mssp_created = 0;
+	game_settings.mssp_ip = "";
+	game_settings.mssp_language = "";
+	game_settings.mssp_location = "";
+	game_settings.mssp_minimum_age = 0;
+	game_settings.mssp_website = "";
+	game_settings.mssp_family = "";
+	game_settings.mssp_genre = "";
+	game_settings.mssp_status = "";
+	game_settings.mssp_gamesystem = "";
+	game_settings.mssp_intermud = "";
+	game_settings.mssp_subgenre = "";
+	game_settings.mssp_discord_server = "";
+	game_settings.mssp_areas = 0;
+	game_settings.mssp_helpfiles = 0;
+	game_settings.mssp_mobiles = 0;
+	game_settings.mssp_objects = 0;
+	game_settings.mssp_rooms = 0;
+	game_settings.mssp_classes = 0;
+	game_settings.mssp_levels = 0;
+	game_settings.mssp_races = 0;
+	game_settings.mssp_skills = 0;
+	game_settings.mssp_dbsize = 0;
+	game_settings.mssp_ansi = false;
+	game_settings.mssp_gmcp = false;
+	game_settings.mssp_mccp = false;
+	game_settings.mssp_mcp = false;
+	game_settings.mssp_msdp = false;
+	game_settings.mssp_msp = false;
+	game_settings.mssp_mxp = false;
+	game_settings.mssp_pueb = false;
+	game_settings.mssp_utf8 = false;
+	game_settings.mssp_vt100 = false;
+	game_settings.mssp_xterm256 = false;
+	game_settings.mssp_xtermtrue = false;
+	game_settings.mssp_atcp = false;
+	game_settings.mssp_ssl = false;
+	game_settings.mssp_pay2play = false;
+	game_settings.mssp_pay4perks = false;
+	game_settings.mssp_hiring_builders = false;
+	game_settings.mssp_hiring_coders = false;
+	game_settings.mssp_adult_material = false;
+	game_settings.mssp_multiclass = false;
+	game_settings.mssp_newbie_friendly = false;
+	game_settings.mssp_player_cities = false;
+	game_settings.mssp_player_clans = false;
+	game_settings.mssp_player_crafting = false;
+	game_settings.mssp_player_guilds = false;
+	game_settings.mssp_equipment_system = "";
+	game_settings.mssp_multiplaying = "";
+	game_settings.mssp_playerkilling = false;
+	game_settings.mssp_quest_system = false;
+	game_settings.mssp_roleplaying = false;
+	game_settings.mssp_training_system = false;
+	game_settings.mssp_world_originality = false;
+
+
+    for(;;)
+    {
+        word = feof (fp) ? "END" : fread_word(fp);
+        fMatch = false;
+
+        switch (UPPER(word[0]))
+        {
+            case '*':
+                fMatch = true;
+                fread_to_eol (fp);
+            break;
+			case 'A':
+				KEY("AllowMultiplayAcctAll", game_settings.allow_multiplay_acct_all, fread_number(fp));
+				KEY("AllowMultiplayAcctStaff", game_settings.allow_multiplay_acct_staff, fread_number(fp));
+				KEY("AllowMultiplayHostAll", game_settings.allow_multiplay_host_all, fread_number(fp));
+				KEY("AllowMultiplayHostStaff", game_settings.allow_multiplay_host_staff, fread_number(fp));
+				break;
+
+           case 'E':
+		   		KEY("Email_Enable", game_settings.enable_email, fread_number(fp));
+		   		KEY("EmailUser", game_settings.email_username, fread_string(fp));
+				KEY("EmailPassword", game_settings.email_password, fread_string(fp));
+				KEY("EmailHost", game_settings.email_host, fread_string(fp));
+				KEY("EmailPort", game_settings.email_port, fread_number(fp));
+				KEY("EmailFromAddr", game_settings.email_from_addr, fread_string(fp));
+				KEY("EmailFromName", game_settings.email_from_name, fread_string(fp));
+                if (!str_cmp(word, "END"))
+                {
+					if (game_settings.idle_disconnect_time <= 0)
+						game_settings.idle_disconnect_time = 30;
+					
+					if (game_settings.idle_time <= 0)
+						game_settings.idle_time = 12;
+
+					if (game_settings.idle_disconnect_time <= game_settings.idle_time)
+						game_settings.idle_disconnect_time = game_settings.idle_time + 5;
+
+					fclose(fp);
+					game_settings_write();
+					return(0); /* Success*/
+				}
+	            break;
+
+			case 'G':
+				KEY("GameName", game_settings.game_name, fread_string(fp));
+				break;
+
+			case 'I':
+				KEY("IdleDisconnectTimeout", game_settings.idle_disconnect_time, fread_number(fp));
+				KEY("IdleTimeout", game_settings.idle_time, fread_number(fp));
+				KEY("IncQuests", game_settings.inc_quests, fread_number(fp));
+				KEY("InsecureWarning_Enable", game_settings.enable_insecure_warning, fread_number(fp));
+				KEY("InsecureWarning_Msg", game_settings.insecure_warning_msg, fread_string(fp));
+				break;
+
+			case 'L':
+				KEY("LogAllConnections", game_settings.logall, fread_number(fp));
+				KEY("LoginString", game_settings.login_string, fread_string(fp));
+				break;
+
+			case 'M':
+				KEY("MaxAlias", game_settings.max_alias, fread_number(fp));
+				KEY("MaxCharacters", game_settings.max_characters, fread_number(fp));
+				KEY("MaxLogfileSize", game_settings.max_logfile_size, fread_number(fp));
+				KEY("MaxLoginAttempts", game_settings.max_login_attempts, fread_number(fp));
+				KEY("MaxQuestAllowance", game_settings.max_quest_allowance, fread_number(fp));
+				KEY("MaxQuests", game_settings.max_quests, fread_number(fp));
+				KEY("MaxChurches", game_settings.max_churches, fread_number(fp));
+				KEY("MSSP_HOSTNAME",game_settings.mssp_hostname,fread_string(fp));
+				KEY("MSSP_CODEBASE",game_settings.mssp_codebase,fread_string(fp));
+				KEY("MSSP_CONTACT",game_settings.mssp_contact,fread_string(fp));
+				KEY("MSSP_IP",game_settings.mssp_ip,fread_string(fp));
+				KEY("MSSP_LANGUAGE",game_settings.mssp_language,fread_string(fp));
+				KEY("MSSP_LOCATION",game_settings.mssp_location,fread_string(fp));
+				KEY("MSSP_WEBSITE",game_settings.mssp_website,fread_string(fp));
+				KEY("MSSP_FAMILY",game_settings.mssp_family,fread_string(fp));
+				KEY("MSSP_GENRE",game_settings.mssp_genre,fread_string(fp));
+				KEY("MSSP_STATUS",game_settings.mssp_status,fread_string(fp));
+				KEY("MSSP_GAMESYSTEM",game_settings.mssp_gamesystem,fread_string(fp));
+				KEY("MSSP_INTERMUD",game_settings.mssp_intermud,fread_string(fp));
+				KEY("MSSP_SUBGENRE",game_settings.mssp_subgenre,fread_string(fp));
+				KEY("MSSP_DISCORD_SERVER",game_settings.mssp_discord_server,fread_string(fp));
+				KEY("MSSP_EQUIPMENT_SYSTEM",game_settings.mssp_equipment_system,fread_string(fp));
+				KEY("MSSP_MULTIPLAYING",game_settings.mssp_multiplaying,fread_string(fp));
+                KEY("MSSP_CRAWL_DELAY",game_settings.mssp_crawl_delay,fread_number(fp));
+                KEY("MSSP_PORT",game_settings.mssp_port,fread_number(fp));
+                KEY("MSSP_TLS_PORT",game_settings.mssp_tls_port,fread_number(fp));
+                KEY("MSSP_CREATED",game_settings.mssp_created,fread_number(fp));
+                KEY("MSSP_MINIMUM_AGE",game_settings.mssp_minimum_age,fread_number(fp));
+                KEY("MSSP_AREAS",game_settings.mssp_areas,fread_number(fp));
+                KEY("MSSP_HELPFILES",game_settings.mssp_helpfiles,fread_number(fp));
+                KEY("MSSP_MOBILES",game_settings.mssp_mobiles,fread_number(fp));
+                KEY("MSSP_OBJECTS",game_settings.mssp_objects,fread_number(fp));
+                KEY("MSSP_ROOMS",game_settings.mssp_rooms,fread_number(fp));
+                KEY("MSSP_CLASSES",game_settings.mssp_classes,fread_number(fp));
+                KEY("MSSP_LEVELS",game_settings.mssp_levels,fread_number(fp));
+                KEY("MSSP_RACES",game_settings.mssp_races,fread_number(fp));
+                KEY("MSSP_SKILLS",game_settings.mssp_skills,fread_number(fp));
+                KEY("MSSP_DBSIZE",game_settings.mssp_dbsize,fread_number(fp));
+                KEY("MSSP_VT100",game_settings.mssp_vt100,fread_number(fp));
+                KEY("MSSP_ANSI",game_settings.mssp_ansi,fread_number(fp));
+				KEY("MSSP_ATCP",game_settings.mssp_atcp,fread_number(fp));
+                KEY("MSSP_GMCP",game_settings.mssp_gmcp,fread_number(fp));
+                KEY("MSSP_MCCP",game_settings.mssp_mccp,fread_number(fp));
+                KEY("MSSP_MCP",game_settings.mssp_mcp,fread_number(fp));
+                KEY("MSSP_MSDP",game_settings.mssp_msdp,fread_number(fp));
+                KEY("MSSP_MSP",game_settings.mssp_msp,fread_number(fp));
+                KEY("MSSP_MXP",game_settings.mssp_mxp,fread_number(fp));
+                KEY("MSSP_PUEB",game_settings.mssp_pueb,fread_number(fp));
+                KEY("MSSP_UTF8",game_settings.mssp_utf8,fread_number(fp));
+                KEY("MSSP_VT100",game_settings.mssp_vt100,fread_number(fp));
+                KEY("MSSP_XTERM256",game_settings.mssp_xterm256,fread_number(fp));
+                KEY("MSSP_XTERMTRUE",game_settings.mssp_xtermtrue,fread_number(fp));
+                KEY("MSSP_ATCP",game_settings.mssp_atcp,fread_number(fp));
+                KEY("MSSP_SSL",game_settings.mssp_ssl,fread_number(fp));
+                KEY("MSSP_PAY2PLAY",game_settings.mssp_pay2play,fread_number(fp));
+                KEY("MSSP_PAY4PERKS",game_settings.mssp_pay4perks,fread_number(fp));
+                KEY("MSSP_HIRING_BUILDERS",game_settings.mssp_hiring_builders,fread_number(fp));
+                KEY("MSSP_HIRING_CODERS",game_settings.mssp_hiring_coders,fread_number(fp));
+                KEY("MSSP_ADULT_MATERIAL",game_settings.mssp_adult_material,fread_number(fp));
+                KEY("MSSP_MULTICLASS",game_settings.mssp_multiclass,fread_number(fp));
+                KEY("MSSP_NEWBIE_FRIENDLY",game_settings.mssp_newbie_friendly,fread_number(fp));
+                KEY("MSSP_PLAYER_CITIES",game_settings.mssp_player_cities,fread_number(fp));
+                KEY("MSSP_PLAYER_CLANS",game_settings.mssp_player_clans,fread_number(fp));
+                KEY("MSSP_PLAYER_CRAFTING",game_settings.mssp_player_crafting,fread_number(fp));
+                KEY("MSSP_PLAYER_GUILDS",game_settings.mssp_player_guilds,fread_number(fp));
+                KEY("MSSP_PLAYERKILLING",game_settings.mssp_playerkilling,fread_number(fp));
+                KEY("MSSP_QUEST_SYSTEM",game_settings.mssp_quest_system,fread_number(fp));
+                KEY("MSSP_ROLEPLAYING",game_settings.mssp_roleplaying,fread_number(fp));
+                KEY("MSSP_TRAINING_SYSTEM",game_settings.mssp_training_system,fread_number(fp));
+                KEY("MSSP_WORLD_ORIGINALITY",game_settings.mssp_world_originality,fread_number(fp));
+				
+
+				break;
+
+            case 'N':
+				KEY("NewAcctLock",game_settings.new_acct_lock,fread_number(fp));
+				KEY("NewAcctLockMsg",game_settings.new_acct_lock_msg,fread_string(fp));
+				KEY("NewCharLock",game_settings.new_char_lock,fread_number(fp));
+				KEY("NewCharLockMsg",game_settings.new_char_lock_msg,fread_string(fp));
+
+	            break;
+
+			case 'R':
+				KEY("Require_2FA_All",game_settings.require_2fa_all,fread_number(fp));
+				KEY("Require_2FA_Staff",game_settings.require_2fa_staff,fread_number(fp));
+				KEY("RequireUniqPassStaff",game_settings.require_uniq_pass_staff,fread_number(fp));
+				break;
+
+			case 'S':
+				KEY("ServerDescription", game_settings.server_description, fread_string(fp));
+				KEY("SSL_Cert_Path",game_settings.ssl_cert_path,fread_string(fp));
+				KEY("SSL_Key_Path",game_settings.ssl_key_path,fread_string(fp));
+				break;
+
+			case 'T':
+                KEY("Telnet_Enable", game_settings.enable_telnet, fread_number(fp));
+				KEY("Telnet_Port", game_settings.telnet_port, fread_number(fp));
+				KEY("Testport", game_settings.testport, fread_number(fp));
+				KEY("Tls_Enable", game_settings.enable_tls, fread_number(fp));
+				KEY("Tls_Port", game_settings.tls_port, fread_number(fp));
+				break;
+			case 'W':
+				KEY("Wizlock_Enable", game_settings.wizlock, fread_number(fp));
+				KEY("Wizlock_Msg", game_settings.wizlock_msg, fread_string(fp));
+				break;
+
+        } /* end switch */
+
+        if (!fMatch)
+        {
+	    sprintf(buf, "act_wiz.c, game_settings_read(): no match for '%s'!", word);
+	    bug(buf, 0);
+            fread_to_eol(fp);
+        }
+    } /* end for */
+
+
+}
+
 
 int gconfig_write(void)
 {
@@ -240,12 +567,6 @@ int gconfig_write(void)
     }
 
 	fprintf(fp, "DBversion %ld\n", (long)VERSION_DB);
-	fprintf(fp, "EmailUser %s~\n", gconfig.email_username);
-	fprintf(fp, "EmailPassword %s~\n", gconfig.email_password);
-	fprintf(fp, "EmailHost %s~\n", gconfig.email_host);
-	fprintf(fp, "EmailPort %d\n", gconfig.email_port);
-	fprintf(fp, "EmailFromAddr %s~\n", gconfig.email_from_addr);
-	fprintf(fp, "EmailFromName %s~\n", gconfig.email_from_name);
     fprintf(fp, "NextMobUID %ld %ld\n", gconfig.next_mob_uid[2], gconfig.next_mob_uid[3]);
     fprintf(fp, "NextObjUID %ld %ld\n", gconfig.next_obj_uid[2], gconfig.next_obj_uid[3]);
     fprintf(fp, "NextTokenUID %ld %ld\n", gconfig.next_token_uid[2], gconfig.next_token_uid[3]);
@@ -255,11 +576,6 @@ int gconfig_write(void)
     fprintf(fp, "NextWildsUID %ld\n", gconfig.next_wilds_uid);
     fprintf(fp, "NextVlinkUID %ld\n", gconfig.next_vlink_uid);
     fprintf(fp, "NextChurchUID %ld\n", gconfig.next_church_uid);
-    if(newlock) fprintf(fp, "Newlock\n");
-    if(wizlock) fprintf(fp, "Wizlock\n");
-    if(is_test_port) fprintf(fp, "Testport\n");
-	fprintf(fp, "DisconnectTimeout %d\n", disconnect_timeout);
-	fprintf(fp, "LimboTimeout %d\n", limbo_timeout);
 
     fprintf(fp, "END\n");
     fclose(fp);
@@ -267,6 +583,147 @@ int gconfig_write(void)
     return(0); /* Success*/
 }
 
+int game_settings_write(void)
+{
+	FILE *fp;
+
+	fp = fopen(GAME_SETTINGS_FILE,"w");
+	if (!fp)
+	{
+		bug("act_wiz.c, game_settings_write(): Unable to open game_settings.rc file for writing.",0);
+		return(1); /* Failure*/
+	}
+
+    fprintf(fp, "GameName %s~\n",  game_settings.game_name);
+    fprintf(fp, "LoginString %s~\n",  game_settings.login_string);
+	fprintf(fp, "ServerDescription %s~\n",  game_settings.server_description);
+
+	/* Port Settings */
+    fprintf(fp, "Telnet_Enable %d\n",  game_settings.enable_telnet);
+    fprintf(fp, "Telnet_Port %d\n",  game_settings.telnet_port);
+    fprintf(fp, "Tls_Enable %d\n",  game_settings.enable_tls);
+    fprintf(fp, "Tls_Port %d\n",  game_settings.tls_port);
+    fprintf(fp, "SSL_Cert_Path %s~\n", game_settings.ssl_cert_path);
+    fprintf(fp, "SSL_Key_Path %s~\n", game_settings.ssl_key_path);
+	fprintf(fp, "Testport %d\n",  game_settings.testport);
+    fprintf(fp, "InsecureWarning_Enable %d\n",  game_settings.enable_insecure_warning);
+    fprintf(fp, "InsecureWarning_Msg %s~\n",  game_settings.insecure_warning_msg);
+
+	/* Various Locks */
+    fprintf(fp, "Wizlock_Enable %d\n",  game_settings.wizlock);
+    fprintf(fp, "Wizlock_Msg %s~\n",  game_settings.wizlock_msg);
+	fprintf(fp, "NewAcctLock %d\n", game_settings.new_acct_lock);
+	fprintf(fp, "NewAcctLockMsg %s~\n", game_settings.new_acct_lock_msg);
+    fprintf(fp, "NewCharLock %d\n", game_settings.new_char_lock);
+    fprintf(fp, "NewCharLockMsg %s~\n", game_settings.new_char_lock_msg);
+
+	/* Quest Stuff */
+    fprintf(fp, "IncQuests %d\n",  game_settings.inc_quests);
+    fprintf(fp, "MaxQuestAllowance %d\n",  game_settings.max_quest_allowance);
+    fprintf(fp, "MaxQuests %d\n",  game_settings.max_quests);
+
+	/* Multiplaying */
+    fprintf(fp, "AllowMultiplayAcctAll %d\n",  game_settings.allow_multiplay_acct_all);
+    fprintf(fp, "AllowMultiplayAcctStaff %d\n",  game_settings.allow_multiplay_acct_staff);
+    fprintf(fp, "AllowMultiplayHostAll %d\n",  game_settings.allow_multiplay_host_all);
+    fprintf(fp, "AllowMultiplayHostStaff %d\n",  game_settings.allow_multiplay_host_staff);
+
+	/* Auth */
+    fprintf(fp, "Require_2FA_All %d\n", game_settings.require_2fa_all);
+    fprintf(fp, "Require_2FA_Staff %d\n", game_settings.require_2fa_staff);
+    fprintf(fp, "RequireUniqPassStaff %d\n", game_settings.require_uniq_pass_staff);
+
+	/* Timeouts */
+    fprintf(fp, "IdleDisconnectTimeout %d\n",  game_settings.idle_disconnect_time);
+    fprintf(fp, "IdleTimeout %d\n",  game_settings.idle_time);
+
+	/* Misc Values */
+    fprintf(fp, "LogAllConnections %d\n",  game_settings.logall);
+    fprintf(fp, "MaxAlias %d\n",  game_settings.max_alias);
+    fprintf(fp, "MaxCharacters %d\n",  game_settings.max_characters);
+    fprintf(fp, "MaxLogfileSize %d\n",  game_settings.max_logfile_size);
+    fprintf(fp, "MaxLoginAttempts %d\n",  game_settings.max_login_attempts);
+	fprintf(fp, "MaxChurches %d\n",  game_settings.max_churches);
+
+	/* Email */
+    fprintf(fp, "Email_Enable %d\n",  game_settings.enable_email);
+    fprintf(fp, "EmailUser %s~\n",  game_settings.email_username);
+    fprintf(fp, "EmailPassword %s~\n",  game_settings.email_password);
+    fprintf(fp, "EmailHost %s~\n",  game_settings.email_host);
+    fprintf(fp, "EmailPort %d\n",  game_settings.email_port);
+    fprintf(fp, "EmailFromAddr %s~\n",  game_settings.email_from_addr);
+    fprintf(fp, "EmailFromName %s~\n",  game_settings.email_from_name);
+
+	/* MSSP */
+    fprintf(fp, "MSSP_HOSTNAME %s~\n", game_settings.mssp_hostname);
+    fprintf(fp, "MSSP_CODEBASE %s~\n", game_settings.mssp_codebase);
+    fprintf(fp, "MSSP_CONTACT %s~\n", game_settings.mssp_contact);
+    fprintf(fp, "MSSP_IP %s~\n", game_settings.mssp_ip);
+    fprintf(fp, "MSSP_LANGUAGE %s~\n", game_settings.mssp_language);
+    fprintf(fp, "MSSP_LOCATION %s~\n", game_settings.mssp_location);
+    fprintf(fp, "MSSP_WEBSITE %s~\n", game_settings.mssp_website);
+    fprintf(fp, "MSSP_FAMILY %s~\n", game_settings.mssp_family);
+    fprintf(fp, "MSSP_GENRE %s~\n", game_settings.mssp_genre);
+    fprintf(fp, "MSSP_STATUS %s~\n", game_settings.mssp_status);
+    fprintf(fp, "MSSP_GAMESYSTEM %s~\n", game_settings.mssp_gamesystem);
+    fprintf(fp, "MSSP_INTERMUD %s~\n", game_settings.mssp_intermud);
+    fprintf(fp, "MSSP_SUBGENRE %s~\n", game_settings.mssp_subgenre);
+    fprintf(fp, "MSSP_DISCORD_SERVER %s~\n", game_settings.mssp_discord_server);
+    fprintf(fp, "MSSP_EQUIPMENT_SYSTEM %s~\n", game_settings.mssp_equipment_system);
+    fprintf(fp, "MSSP_MULTIPLAYING %s~\n", game_settings.mssp_multiplaying);
+    fprintf(fp, "MSSP_CRAWL_DELAY %d\n", game_settings.mssp_crawl_delay);
+    fprintf(fp, "MSSP_PORT %d\n", game_settings.mssp_port);
+    fprintf(fp, "MSSP_TLS_PORT %d\n", game_settings.mssp_tls_port);
+    fprintf(fp, "MSSP_CREATED %d\n", game_settings.mssp_created);
+    fprintf(fp, "MSSP_MINIMUM_AGE %d\n", game_settings.mssp_minimum_age);
+    fprintf(fp, "MSSP_AREAS %d\n", game_settings.mssp_areas);
+    fprintf(fp, "MSSP_HELPFILES %d\n", game_settings.mssp_helpfiles);
+    fprintf(fp, "MSSP_MOBILES %d\n", game_settings.mssp_mobiles);
+    fprintf(fp, "MSSP_OBJECTS %d\n", game_settings.mssp_objects);
+    fprintf(fp, "MSSP_ROOMS %d\n", game_settings.mssp_rooms);
+    fprintf(fp, "MSSP_CLASSES %d\n", game_settings.mssp_classes);
+    fprintf(fp, "MSSP_LEVELS %d\n", game_settings.mssp_levels);
+    fprintf(fp, "MSSP_RACES %d\n", game_settings.mssp_races);
+    fprintf(fp, "MSSP_SKILLS %d\n", game_settings.mssp_skills);
+    fprintf(fp, "MSSP_DBSIZE %d\n", game_settings.mssp_dbsize);
+    fprintf(fp, "MSSP_VT100 %d\n", game_settings.mssp_vt100);
+    fprintf(fp, "MSSP_ANSI %d\n", game_settings.mssp_ansi);
+    fprintf(fp, "MSSP_ATCP %d\n", game_settings.mssp_atcp);
+    fprintf(fp, "MSSP_GMCP %d\n", game_settings.mssp_gmcp);
+    fprintf(fp, "MSSP_MCCP %d\n", game_settings.mssp_mccp);
+    fprintf(fp, "MSSP_MCP %d\n", game_settings.mssp_mcp);
+    fprintf(fp, "MSSP_MSDP %d\n", game_settings.mssp_msdp);
+    fprintf(fp, "MSSP_MSP %d\n", game_settings.mssp_msp);
+    fprintf(fp, "MSSP_MXP %d\n", game_settings.mssp_mxp);
+    fprintf(fp, "MSSP_PUEB %d\n", game_settings.mssp_pueb);
+    fprintf(fp, "MSSP_UTF8 %d\n", game_settings.mssp_utf8);
+    fprintf(fp, "MSSP_VT100 %d\n", game_settings.mssp_vt100);
+    fprintf(fp, "MSSP_XTERM256 %d\n", game_settings.mssp_xterm256);
+    fprintf(fp, "MSSP_XTERMTRUE %d\n", game_settings.mssp_xtermtrue);
+    fprintf(fp, "MSSP_ATCP %d\n", game_settings.mssp_atcp);
+    fprintf(fp, "MSSP_SSL %d\n", game_settings.mssp_ssl);
+    fprintf(fp, "MSSP_PAY2PLAY %d\n", game_settings.mssp_pay2play);
+    fprintf(fp, "MSSP_PAY4PERKS %d\n", game_settings.mssp_pay4perks);
+    fprintf(fp, "MSSP_HIRING_BUILDERS %d\n", game_settings.mssp_hiring_builders);
+    fprintf(fp, "MSSP_HIRING_CODERS %d\n", game_settings.mssp_hiring_coders);
+    fprintf(fp, "MSSP_ADULT_MATERIAL %d\n", game_settings.mssp_adult_material);
+    fprintf(fp, "MSSP_MULTICLASS %d\n", game_settings.mssp_multiclass);
+    fprintf(fp, "MSSP_NEWBIE_FRIENDLY %d\n", game_settings.mssp_newbie_friendly);
+    fprintf(fp, "MSSP_PLAYER_CITIES %d\n", game_settings.mssp_player_cities);
+    fprintf(fp, "MSSP_PLAYER_CLANS %d\n", game_settings.mssp_player_clans);
+    fprintf(fp, "MSSP_PLAYER_CRAFTING %d\n", game_settings.mssp_player_crafting);
+    fprintf(fp, "MSSP_PLAYER_GUILDS %d\n", game_settings.mssp_player_guilds);
+    fprintf(fp, "MSSP_PLAYERKILLING %d\n", game_settings.mssp_playerkilling);
+    fprintf(fp, "MSSP_QUEST_SYSTEM %d\n", game_settings.mssp_quest_system);
+    fprintf(fp, "MSSP_ROLEPLAYING %d\n", game_settings.mssp_roleplaying);
+    fprintf(fp, "MSSP_TRAINING_SYSTEM %d\n", game_settings.mssp_training_system);
+    fprintf(fp, "MSSP_WORLD_ORIGINALITY %d\n", game_settings.mssp_world_originality);
+
+
+	fprintf(fp, "END\n");
+	fclose(fp);
+    return(0); /* Success*/
+}
 
 void do_wiznet(CHAR_DATA *ch, char *argument)
 {
@@ -3957,7 +4414,7 @@ void do_purge(CHAR_DATA *ch, char *argument)
 			CHAR_DATA *victim;
 			OBJ_DATA  *obj_next;
 
-			if (arg2 != '\0' && !str_cmp(arg2, "force"))
+			if (!str_cmp(arg2, "force"))
 			{
 				if (ch->tot_level != MAX_LEVEL)
 				{
@@ -4479,20 +4936,42 @@ void do_peace(CHAR_DATA *ch, char *argument)
 
 void do_wizlock(CHAR_DATA *ch, char *argument)
 {
-    wizlock = !wizlock;
 
-    if (wizlock)
-    {
-	wiznet("$N has wizlocked the game.",ch,NULL,0,0,0);
-	send_to_char("Game wizlocked.\n\r", ch);
-    }
-    else
-    {
-	wiznet("$N removes wizlock.",ch,NULL,0,0,0);
-	send_to_char("Game un-wizlocked.\n\r", ch);
+	if (argument[0] == '\0')
+	{
+    	if (!game_settings.wizlock)
+    	{
+			wiznet("$N has wizlocked the game.",ch,NULL,0,0,0);
+			send_to_char("Game wizlocked.\n\r", ch);
+			game_settings.wizlock = true;
+    	}
+    	else
+    	{
+			wiznet("$N removes wizlock.",ch,NULL,0,0,0);
+			send_to_char("Game un-wizlocked.\n\r", ch);
+			game_settings.wizlock = false;
+    	}
+	}
+	else if (!str_cmp(argument, "clear"))
+	{
+		if (!IS_NULLSTR(game_settings.wizlock_msg))
+		{
+			free_string(game_settings.wizlock_msg);
+			game_settings.wizlock_msg = str_dup("");
+		}
+	}
+	else
+	{
+		if (!IS_NULLSTR(game_settings.wizlock_msg))
+		{
+			free_string(game_settings.wizlock_msg);
+		}
+		game_settings.wizlock_msg = str_dup(argument);
+		wiznet("$N sets wizlock message.",ch,NULL,0,0,0);
+		send_to_char("Wizlock message set.\n\r", ch);
     }
 
-	gconfig_write();
+	game_settings_write();
 
 }
 
@@ -4500,26 +4979,97 @@ void do_wizlock(CHAR_DATA *ch, char *argument)
 void do_newlock(CHAR_DATA *ch, char *argument)
 {
     newlock = !newlock;
+	char arg[MIL];
 
-    if (newlock)
-    {
-	wiznet("$N locks out new characters.",ch,NULL,0,0,0);
-        send_to_char("New characters have been locked out.\n\r", ch);
-    }
-    else
-    {
-	wiznet("$N allows new characters back in.",ch,NULL,0,0,0);
-        send_to_char("Newlock removed.\n\r", ch);
-    }
+	if (argument[0] == '\0')
+	{
+    	send_to_char("Syntax: newlock <char|acct> [$message|clear]\n\r", ch);
+		return;
+	}
+	else
+	{
+		argument = one_argument(argument, arg);
+		if (!str_cmp(arg, "char"))
+		{
+			if (argument[0] == '\0')
+			{
+				if (!game_settings.new_char_lock)
+				{
+					wiznet("$N locks out new characters.",ch,NULL,0,0,0);
+					send_to_char("New characters have been locked out.\n\r", ch);
+					game_settings.new_char_lock = true;
+				}
+				else
+				{
+					wiznet("$N allows new characters back in.",ch,NULL,0,0,0);
+					send_to_char("New characters are no longer locked out.\n\r", ch);
+					game_settings.new_char_lock = false;
+				}
+			}
+			else if (!str_cmp(argument, "clear"))
+			{
+				if (!IS_NULLSTR(game_settings.new_char_lock_msg))
+				{
+					free_string(game_settings.new_char_lock_msg);
+					game_settings.new_char_lock_msg = str_dup("");
+				}
+			}
+			else
+			{
+				if (!IS_NULLSTR(game_settings.new_char_lock_msg))
+				{
+					free_string(game_settings.new_char_lock_msg);
+				}
+				game_settings.new_char_lock_msg = str_dup(argument);
+				wiznet("$N sets new character message.",ch,NULL,0,0,0);
+				send_to_char("New character message set.\n\r", ch);
+			}
+		}
+		else if (!str_cmp(arg, "acct"))
+		{
+			if (argument[0] == '\0')
+			{
+				if (!game_settings.new_acct_lock)
+				{
+					wiznet("$N locks out new accounts.",ch,NULL,0,0,0);
+					send_to_char("New accounts have been locked out.\n\r", ch);
+					game_settings.new_acct_lock = true;
+				}
+				else
+				{
+					wiznet("$N allows new accounts back in.",ch,NULL,0,0,0);
+					send_to_char("New accounts are no longer locked out.\n\r", ch);
+					game_settings.new_acct_lock = false;
+				}
+			}
+			else if (!str_cmp(argument, "clear"))
+			{
+				if (!IS_NULLSTR(game_settings.new_acct_lock_msg))
+				{
+					free_string(game_settings.new_acct_lock_msg);
+					game_settings.new_acct_lock_msg = str_dup("");
+				}
+			}
+			else
+			{
+				if (!IS_NULLSTR(game_settings.new_acct_lock_msg))
+				{
+					free_string(game_settings.new_acct_lock_msg);
+				}
+				game_settings.new_acct_lock_msg = str_dup(argument);
+				wiznet("$N sets new account message.",ch,NULL,0,0,0);
+				send_to_char("New account message set.\n\r", ch);
+			}
+		}
+		game_settings_write();
+	}
 
-	gconfig_write();
 }
 
 void do_testport(CHAR_DATA *ch, char *argument)
 {
-    is_test_port = !is_test_port;
 
-    if (is_test_port)
+    if (!game_settings.testport)
     {
 		wiznet("$N enables Test Port Mode.",ch,NULL,0,0,0);
 		send_to_char("Test Port Mode enabled.\n\r", ch);
@@ -4529,7 +5079,7 @@ void do_testport(CHAR_DATA *ch, char *argument)
 		wiznet("$N disables Test Port Mode.",ch,NULL,0,0,0);
 		send_to_char("Test Port Mode disabled.\n\r", ch);
     }
-    gconfig_write();
+    game_settings_write();
 }
 
 /*
@@ -6292,6 +6842,7 @@ void do_sockets( CHAR_DATA *ch, char *argument )
               case CON_CHANGE_PASSWORD_CONFIRM:	st = "Confirm PassChg";	break;
               case CON_GET_EMAIL:			 st = "   Get Email   ";	break;
 			  case CON_CONFIRM_EMAIL_FOR_RESET: st = " Confirm Email ";	break;
+			  case CON_GET_MFA:					st = " Get MFA "; break;
               default:                       st = "   !UNKNOWN!   ";    break;
            }
            count++;
@@ -6305,7 +6856,8 @@ void do_sockets( CHAR_DATA *ch, char *argument )
            else
               sprintf( idle, "  " );
 
-           sprintf(buf, "{D[{x%3d %s %7s{g %2s{D]{W %-12s{x %-50.50s\n\r",
+			sprintf(buf, "{D[{x%s%3d{X %s %7s{g %2s{D]{W %-12s{x %-50.50s\n\r",
+			  d->ssl ? "{G": "{X",
               d->descriptor,
               st,
               s,
@@ -9051,7 +9603,7 @@ void do_pwreset(CHAR_DATA *ch, char *argument)
 
 					if (email[0] != '\0')
 					{
-						send_email_async(d.character, email, reset_subject, reset_msg);
+						send_email_async(d.character, email, reset_subject, reset_msg, NULL, NULL);
 						sprintf(buf, "Password reset code has been sent to %s for %s.\n\r", email, plr);
 						send_to_char(buf, ch);
 					}
@@ -9063,7 +9615,7 @@ void do_pwreset(CHAR_DATA *ch, char *argument)
 							return;
 						}
 
-						send_email_async(d.character, d.character->pcdata->email, reset_subject, reset_msg);
+						send_email_async(d.character, d.character->pcdata->email, reset_subject, reset_msg, NULL, NULL);
 						sprintf(buf, "Password reset code has been sent to %s for %s.\n\r", d.character->pcdata->email, plr);
 						send_to_char(buf, ch);
 					}
@@ -9083,6 +9635,82 @@ void do_pwreset(CHAR_DATA *ch, char *argument)
 			send_to_char("That player does not exist.\n\r", ch);
 			return;
 		}
+	}
+}
+
+void do_mfareset(CHAR_DATA *ch, char *argument)
+{
+	CHAR_DATA *victim;
+	char plr[MAX_INPUT_LENGTH];
+	char buf[MAX_STRING_LENGTH];
+	DESCRIPTOR_DATA d;
+	bool mfa_reset = false;
+
+	argument = one_argument(argument, plr);
+
+	if (plr[0] == '\0')
+	{
+		send_to_char("Reset MFA for whom?\n\rSyntax: mfareset <character>\n\r", ch);
+		return;
+	}
+
+	if ((player_exists(plr)))
+	{
+		if ((victim = get_char_world(ch, plr)) == NULL)
+		{
+			if (!load_char_obj(&d, plr))
+			{
+				send_to_char("That player does not exist.\n\r", ch);
+				return;
+			}
+			else
+			{
+				d.character->desc = NULL;
+
+				if (d.character->pcdata->mfa_enabled)
+				{
+					d.character->pcdata->mfa_enabled = false;
+					mfa_reset = true;
+				}
+				if (!IS_NULLSTR(d.character->pcdata->mfa_key))
+				{
+					free_string(d.character->pcdata->mfa_key);
+					d.character->pcdata->mfa_key = str_dup("");
+					mfa_reset = true;
+				}
+				if (d.character->pcdata->qr_code_expiration != 0)
+				{
+					d.character->pcdata->qr_code_expiration = 0;
+					mfa_reset = true;
+				}
+
+				if (mfa_reset)
+				{
+					sprintf(buf, "Multifactor auth has been disabled for %s.\n\r", d.character->name);
+					send_to_char(buf, ch);
+					save_char_obj(d.character);
+				}
+				else
+				{
+					sprintf(buf, "Multifactor auth was not enabled for %s.\n\r", d.character->name);
+					send_to_char(buf,ch);
+				}
+
+				free_char(d.character);
+
+
+			}
+		}
+		else
+		{
+			send_to_char("That player is already online.\n\r", ch);
+			return;
+		}
+	}
+	else
+	{
+		send_to_char("That player does not exist.\n\r", ch);
+		return;
 	}
 }
 

--- a/cmdedit.c
+++ b/cmdedit.c
@@ -1033,10 +1033,10 @@ CMDEDIT ( cmdedit_summary )
 CMDEDIT ( cmdedit_order )
 {
 
-
+/*
     send_to_char("Disabled pending further work.\n\r", ch);
     return false;
-
+*/
 
     CMD_DATA *command;
 

--- a/comm.c
+++ b/comm.c
@@ -108,6 +108,8 @@ void join_world args ((DESCRIPTOR_DATA * d));
  * External functions.
  */
 extern void boat_attack(CHAR_DATA *ch);
+extern void init_string_space();
+
 
 
 /*
@@ -412,7 +414,7 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
-
+	init_string_space();
 
     /*
      * Init time.

--- a/comm.c
+++ b/comm.c
@@ -62,6 +62,8 @@
 #include <zlib.h>
 /* VIZZWILDS - support for plogf() and printf_to_char() functions*/
 #include <stdarg.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
 
 #include "strings.h"
 #include "merc.h"
@@ -70,7 +72,6 @@
 #include "scripts.h"
 #include "tables.h"
 #include "wilds.h"
-#include "sha256.h"
 
 /*
  * Socket and TCP/IP stuff.
@@ -113,9 +114,10 @@ extern void boat_attack(CHAR_DATA *ch);
  * Global variables.
  */
 bool			is_test_port;
-int 		    port;
-int				port_tls;
+int 		    telnet_port;
+int				tls_port;
 GLOBAL_DATA         gconfig;		/* Vizz - UID Tracking, and any other persistent global config info */
+GAME_SETTINGS_DATA  game_settings;
 LLIST *conn_players;
 LLIST *conn_immortals;
 LLIST *conn_online;
@@ -131,16 +133,18 @@ time_t		    current_time;	/* time of this pulse */
 time_t			stats_load_time;
 bool		    MOBtrigger = true;  /* act() switch                 */
 LLIST *loaded_areas;
+SSL_CTX *ctx;
 
 /*
  * OS-dependent local functions.
  */
-void	game_loop		args((int control));
+void	game_loop		args((int control_telnet, int control_tls));
 int	init_socket		args((int port));
-void	init_descriptor		args((int control));
+int init_tls_socket	args((int port));
+void	init_descriptor		args((int control, bool is_tls));
 bool	read_from_descriptor	args((DESCRIPTOR_DATA *d));
 bool	write_to_descriptor	args((DESCRIPTOR_DATA *d, char *txt, int length));
-bool	write_to_descriptor_2	args((int desc, char *txt, int length));
+bool	write_to_descriptor_2	args((DESCRIPTOR_DATA *d, char *txt, int length));
 
 
 /*
@@ -170,9 +174,11 @@ char logfile_err[MIL];
 static void RedirectSTDOUT(void)
 {
 	FILE *newfp;
+	char log_time[100];
 
 	/* Redirect standard input and standard output*/
-	sprintf(logfile_std,"../log/sent%d_%d.log",port,(int)time(NULL));
+	strftime(log_time, 100, "%F-%X", localtime(&current_time));
+	sprintf(logfile_std,"../log/sent_%s.log",log_time);
 	if(!(newfp = freopen(logfile_std,"a",stdout))) { /* This happens on NT*/
 #if !defined(stdout)
 		stdout = fopen(logfile_std,"a");
@@ -190,9 +196,11 @@ static void RedirectSTDOUT(void)
 static void RedirectSTDERR(void)
 {
 	FILE *newfp;
+	char log_time[100];
 
 	/* Redirect standard input and standard output*/
-	sprintf(logfile_err,"../log/sent%d_%d.err",port,(int)time(NULL));
+	strftime(log_time, 100, "%F-%X", localtime(&current_time));
+	sprintf(logfile_err,"../log/sent_%s.err",log_time);
 	if(!(newfp = freopen(logfile_err,"a",stderr))) { /* This happens on NT*/
 #if !defined(stdout)
 		stdout = fopen(logfile_err,"a");
@@ -254,12 +262,12 @@ static void CleanupLogs(void)
 
 static void check_logfile(void)
 {
-	if(ftell(stdout) > MAX_LOGFILE) {
+	if(ftell(stdout) > game_settings.max_logfile_size) {
 		CleanupSTDOUT();
 		RedirectSTDOUT();
 	}
 
-	if(ftell(stderr) > MAX_LOGFILE) {
+	if(ftell(stderr) > game_settings.max_logfile_size) {
 		CleanupSTDERR();
 		RedirectSTDERR();
 	}
@@ -281,7 +289,7 @@ bool parse_options(int argc, char **argv)
 				return false;
 			}
 
-			port = p;
+			telnet_port = p;
 		}
 		else if ( argv[i][0] == '-' && (strlen(argv[i]) == 2) )
 		{
@@ -325,9 +333,11 @@ int main(int argc, char **argv)
 {
     
     struct timeval now_time;
-    int control;
+    int control_telnet = 0;
+	int control_tls = 0;
     ITERATOR iter;
     void *data;
+	static GAME_SETTINGS_DATA game_settings_zero;
 
     /*
      * Memory debugging if needed.
@@ -420,11 +430,17 @@ int main(int argc, char **argv)
 	exit(1);
     }
 
+	game_settings = game_settings_zero;
+	if (game_settings_read()==1) exit(1);
+	log_string("Global game settings loaded.");
+
     /*
      * Get the port number.
      */
-    port = 9000;
-	port_tls = 9001;
+	if (game_settings.telnet_port)
+		telnet_port = game_settings.telnet_port;
+	if (game_settings.tls_port)
+		tls_port = game_settings.tls_port;
     is_test_port = false;
     newlock = false;
     wizlock = false;
@@ -475,15 +491,33 @@ int main(int argc, char **argv)
     /*
      * Run the game.
      */
-    control = init_socket(port);
+	if ((!game_settings.enable_telnet && game_settings.telnet_port) && (!game_settings.enable_tls && game_settings.tls_port && !IS_NULLSTR(game_settings.ssl_cert_path) && !IS_NULLSTR(game_settings.ssl_key_path)))
+	{
+		fprintf(stderr, "No available connection options. Please set enable_telnet and telnet_port, and/or enable_tls and tls_port, along with ssl_cert_path and ssl_key_path in the game_settings table.\n");
+		exit(1);
+	}
+
+	if (game_settings.enable_telnet)
+	{
+    	control_telnet = init_socket(telnet_port);
+		sprintf(log_buf, "Telnet socket bound to port %d.", telnet_port);
+		log_string(log_buf);
+	}
+	if (game_settings.enable_tls && game_settings.tls_port)
+	{
+		control_tls = init_tls_socket(tls_port);
+		sprintf(log_buf, "TLS socket bound to port %d.", tls_port);
+		log_string(log_buf);
+	}
+
     boot_db();
 
-    sprintf(log_buf, "Sentience is up on port %d.", port);
+    sprintf(log_buf, "Sentience is up on %d.", telnet_port);
     log_string(log_buf);
     #ifdef IMC
     imc_startup( false, -1, false );
     #endif
-    game_loop(control);
+    game_loop(control_telnet, control_tls);
 	list_destroy(conn_players);
 	list_destroy(conn_immortals);
 	list_destroy(conn_online);
@@ -505,7 +539,10 @@ int main(int argc, char **argv)
 	iterator_stop(&iter);
 	list_destroy(loaded_wilds);
 	list_destroy(list_churches);
-    close (control);
+	if (game_settings.enable_telnet)
+    	close (control_telnet);
+	if (game_settings.enable_tls)
+		close(control_tls);
 	#ifdef IMC
 	SERVER_DATA *server;
 	extern SERVER_DATA *first_server;
@@ -612,7 +649,76 @@ int init_socket(int port)
     return fd;
 }
 
-void game_loop(int control)
+int init_tls_socket(int port)
+{
+    static struct sockaddr_in sa_zero;
+    struct sockaddr_in sa;
+    int x = 1;
+    int fd;
+
+    if ((fd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
+    {
+	perror("Init_socket: socket");
+	exit(1);
+    }
+
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR,
+    (char *) &x, sizeof(x)) < 0)
+    {
+	perror("Init_socket: SO_REUSEADDR");
+	close(fd);
+	exit(1);
+    }
+
+#if defined(SO_DONTLINGER) && !defined(SYSV)
+    {
+	struct	linger	ld;
+
+	ld.l_onoff  = 1;
+	ld.l_linger = 1000;
+
+	if (setsockopt(fd, SOL_SOCKET, SO_DONTLINGER,
+	(char *) &ld, sizeof(ld)) < 0)
+	{
+	    perror("Init_socket: SO_DONTLINGER");
+	    close(fd);
+	    exit(1);
+	}
+    }
+#endif
+
+    sa		    = sa_zero;
+    sa.sin_family   = AF_INET;
+    sa.sin_port	    = htons(port);
+
+    if (bind(fd, (struct sockaddr *) &sa, sizeof(sa)) < 0)
+    {
+	perror("Init socket: bind");
+	close(fd);
+	exit(1);
+    }
+
+
+    if (listen(fd, 3) < 0)
+    {
+	perror("Init socket: listen");
+	close(fd);
+	exit(1);
+    }
+
+	// Initialize SSL library
+    init_openssl_library();
+
+    // Create SSL context
+    ctx = create_context();
+
+    // Configure SSL context
+    configure_context(ctx);
+
+    return fd;
+}
+
+void game_loop(int control_telnet, int control_tls)
 {
     static struct timeval null_time;
     struct timeval last_time;
@@ -628,7 +734,7 @@ void game_loop(int control)
 	fd_set out_set;
 	fd_set exc_set;
 	DESCRIPTOR_DATA *d;
-	int maxdesc;
+	int maxdesc = 0;
 
 #if defined(MALLOC_DEBUG)
 	if (malloc_verify() != 1)
@@ -641,14 +747,39 @@ void game_loop(int control)
 	FD_ZERO(&in_set );
 	FD_ZERO(&out_set);
 	FD_ZERO(&exc_set);
-	FD_SET(control, &in_set);
-	maxdesc	= control;
+	if (control_telnet != -1 && game_settings.enable_telnet)
+	{
+		FD_SET(control_telnet, &in_set);
+		maxdesc	= control_telnet;
+	}
+	if (control_tls != -1 && game_settings.enable_tls)
+	{
+		FD_SET(control_tls, &in_set);
+		maxdesc	= control_tls;
+	}
+
+/*
 	for (d = descriptor_list; d; d = d->next)
 	{
 	    maxdesc = UMAX(maxdesc, d->descriptor);
 	    FD_SET(d->descriptor, &in_set );
 	    FD_SET(d->descriptor, &out_set);
 	    FD_SET(d->descriptor, &exc_set);
+	}
+*/
+for (d = descriptor_list; d; d = d->next)
+{
+    FD_SET(d->descriptor, &in_set);
+    FD_SET(d->descriptor, &out_set);
+	FD_SET(d->descriptor, &exc_set);
+	
+    maxdesc = UMAX(maxdesc, d->descriptor);
+/*
+    if (d->ssl && d->tls_handshake_in_progress) {
+        // If the TLS handshake is in progress, we want to wait for write events
+        FD_SET(d->descriptor, &out_set);
+    }
+*/
 	}
 
 	if (select(maxdesc+1, &in_set, &out_set, &exc_set, &null_time) < 0)
@@ -685,8 +816,11 @@ void game_loop(int control)
 	/*
 	 * New connection?
 	 */
-	if (FD_ISSET(control, &in_set))
-	    init_descriptor(control);
+	if (FD_ISSET(control_telnet, &in_set))
+	    init_descriptor(control_telnet, false);
+	
+	if (FD_ISSET(control_tls, &in_set))
+		init_descriptor(control_tls, true);
 
 	/*
 	 * Kick out the freaky folks.
@@ -717,6 +851,49 @@ void game_loop(int control)
 
 	    if (FD_ISSET(d->descriptor, &in_set))
 	    {
+			if (d->character != NULL)
+		    	d->character->timer = 0;
+
+			if (!read_from_descriptor(d))
+			{
+		    	FD_CLR(d->descriptor, &out_set);
+
+	    		if (d->character != NULL
+		    		&&   d->connected == CON_PLAYING)
+				save_char_obj(d->character);
+
+	    		d->outtop	= 0;
+	    		close_socket(d);
+	    		continue;
+			}
+
+	    	d->muted = 0;
+
+			if (d->ssl && d->tls_handshake_in_progress && FD_ISSET(d->descriptor, &out_set)) 
+			{
+				int ret = SSL_accept(d->ssl);
+				if (ret == 1)
+					d->tls_handshake_in_progress = false;
+				else if (ret == 0)
+				{
+					close_socket(d);
+					continue;
+				} 
+				else 
+				{
+					int err = SSL_get_error(d->ssl, ret);
+					if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+						continue;
+					} 
+					else 
+					{
+						close_socket(d);
+						continue;
+					}
+				}
+			}/*
+			else
+	    {
 		if (d->character != NULL)
 		    d->character->timer = 0;
 
@@ -734,7 +911,8 @@ void game_loop(int control)
 		}
 
 		    d->muted = 0;		// Force it to unmute every time they give any kind of command
-	    }
+	    }*/
+		}
 
 	    if (d->character != NULL && d->character->wait > 0)
 	    {
@@ -886,7 +1064,7 @@ imc_loop();
 }
 
 
-void init_descriptor(int control)
+void init_descriptor(int control, bool is_tls)
 {
     char buf[MAX_STRING_LENGTH];
     DESCRIPTOR_DATA *dnew;
@@ -917,6 +1095,42 @@ void init_descriptor(int control)
      * Cons a new descriptor.
      */
     dnew = new_descriptor();
+
+
+	if (is_tls) {
+		dnew->ssl = SSL_new(ctx);
+		dnew->tls_handshake_in_progress = true;
+		if (dnew->ssl == NULL) {
+			bug("New_descriptor: SSL_new failed", 0);
+			return;
+		}
+
+		if (SSL_set_fd(dnew->ssl, desc) == 0) {
+			bug("New_descriptor: SSL_set_fd failed", 0);
+			return;
+		}
+
+// When you first accept a new TLS connection:
+int ret = SSL_accept(dnew->ssl);
+if (ret <= 0) {
+    int err = SSL_get_error(dnew->ssl, ret);
+    if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+        // The operation did not complete; the same I/O function should be called again later
+        dnew->tls_handshake_in_progress = true;
+    } else {
+        fprintf(stderr, "SSL error: %d\n", err);
+        ERR_print_errors_fp(stderr);
+        return;
+    }
+} else {
+    // Handshake was successful
+    dnew->tls_handshake_in_progress = false;
+}
+	}
+	else
+	{
+		dnew->ssl = NULL;
+	}
 
     dnew->descriptor	= desc;
     dnew->connected	= CON_GET_NAME;
@@ -965,8 +1179,9 @@ void init_descriptor(int control)
      */
     if (check_ban(dnew->host,BAN_ALL))
     {
-	write_to_descriptor_2(desc,
-	    "Your site has been banned from Sentience.\n\r", 0);
+		char banmsg[MIL];
+		sprintf(banmsg, "Your site has been banned from %s\n\r", game_settings.game_name);
+	write_to_descriptor_2(dnew, banmsg, 0);
 	close(desc);
 	free_descriptor(dnew);
 	return;
@@ -989,11 +1204,25 @@ void init_descriptor(int control)
     //write_to_buffer(dnew, msp_will, 0);
 
     if (help_greeting[0] == '.')
-	write_to_buffer(dnew, help_greeting+1, 0);
+		write_to_buffer(dnew, help_greeting+1, 0);
     else
-	write_to_buffer(dnew, help_greeting  , 0);
+		write_to_buffer(dnew, help_greeting  , 0);
 
-    write_to_buffer(dnew, "By what name do you wish to be known? ", 0);
+	if (!is_tls && game_settings.enable_tls && game_settings.enable_insecure_warning && game_settings.insecure_warning_msg != NULL)
+	{
+		sprintf(buf, "{R%s{x\n\r{XIf your client supports it, encrypted connection is available on port %d\n\r\n\r", game_settings.insecure_warning_msg, game_settings.tls_port);
+		write_to_buffer(dnew, buf, 0);
+	}
+
+	if (!IS_NULLSTR(game_settings.login_string))
+	{
+		write_to_buffer(dnew, game_settings.login_string, 0);
+		write_to_buffer(dnew, "\n\r", 0);
+	}
+	else
+	{
+    	write_to_buffer(dnew, "By what name do you wish to be known? ", 0);
+	}
 }
 
 
@@ -1092,8 +1321,7 @@ bool read_from_descriptor(DESCRIPTOR_DATA *d)
     {
 	sprintf(log_buf, "%s input overflow!", d->host);
 	log_string(log_buf);
-	write_to_descriptor(d,
-	    "\n\r*** PUT A LID ON IT!!! ***\n\r", 0);
+	write_to_descriptor(d, "\n\r*** PUT A LID ON IT!!! ***\n\r", 0);
 	return false;
     }
 
@@ -1111,8 +1339,31 @@ bool read_from_descriptor(DESCRIPTOR_DATA *d)
 		break;
 	}
 */
-	nRead = read( d->descriptor, read_buf + iStart,
-	    sizeof(read_buf) - 10 - iStart );
+	if (d->ssl)
+	{
+		do {
+			nRead = SSL_read(d->ssl, read_buf + iStart, sizeof(read_buf) - 10 - iStart);
+				if (nRead <= 0) {
+					int err = SSL_get_error(d->ssl, nRead);
+				if (err == SSL_ERROR_WANT_READ) {
+					// The operation did not complete; the same I/O function should be called again later
+					break;
+				} else {
+					fprintf(stderr, "SSL_read failed with error: %d\n", err);
+					ERR_print_errors_fp(stderr);
+						fprintf(stderr, "SSL state: %s\n", SSL_state_string_long(d->ssl));
+					ERR_print_errors_fp(stderr);
+					return false;
+				}
+			}
+		} while (nRead <= 0);
+
+	}
+	else
+	{
+		nRead = read( d->descriptor, read_buf + iStart,
+			sizeof(read_buf) - 10 - iStart );
+	}
 	if ( nRead > 0 )
 	{
 	    iStart += nRead;
@@ -1444,6 +1695,12 @@ void bust_a_prompt(CHAR_DATA *ch)
 		return;
 	}
 
+	if (!IS_NPC(ch) && ch->pcdata->mfa_question)
+	{
+		send_to_char("{YMFA Code:{X\n\r", ch);
+		return;
+	}
+
     if (ch->pk_question || ch->remove_question)
     {
 	send_to_char("{Y({xY{R/{xN{Y){x\n\r", ch);
@@ -1675,6 +1932,15 @@ void bust_a_prompt(CHAR_DATA *ch)
 		else
 			sprintf(buf2, " ");
 		i = buf2; break;
+	case '+':
+		sprintf(buf2, game_settings.server_description);
+		i = buf2; break;
+	case '-':
+		sprintf(buf2, ch->desc->ssl ? "{G[SECURE]{X" : "{R[INSECURE]{X");
+		i = buf2; break;
+	case '_':
+		sprintf(buf2, ch->name);
+		i = buf2; break;
 	case '%' :
 		sprintf(buf2, "%%");
 		i = buf2; break;
@@ -1784,20 +2050,38 @@ void write_to_buffer(DESCRIPTOR_DATA *d, const char *txt, int length)
  * If this gives errors on very long blocks (like 'ofind all'),
  *   try lowering the max block size.
  */
-bool write_to_descriptor_2(int desc, char *txt, int length)
+bool write_to_descriptor_2(DESCRIPTOR_DATA *d, char *txt, int length)
 {
     int iStart;
     int nWrite;
     int nBlock;
 
-    if (length <= 0)
-	length = strlen(txt);
+    if (d->out_compress)
+        return writeCompressed(d, txt, length);
 
     for (iStart = 0; iStart < length; iStart += nWrite)
     {
-	nBlock = UMIN(length - iStart, 4096);
-	if ((nWrite = write(desc, txt + iStart, nBlock)) < 0)
-	    { perror("Write_to_descriptor"); return false; }
+		nBlock = UMIN(length - iStart, 4096);
+		if (d->ssl) {
+			nWrite = SSL_write(d->ssl, txt + iStart, nBlock);
+			if (nWrite <= 0) {
+				int err = SSL_get_error(d->ssl, nWrite);
+				if (err == SSL_ERROR_WANT_WRITE) {
+				// The operation did not complete; the same I/O function should be called again later
+					break;
+				} else {
+					fprintf(stderr, "SSL_write failed with error: %d\n", err);
+					ERR_print_errors_fp(stderr);
+					return false;
+				}
+			}
+		} else {
+			nWrite = write(d->descriptor, txt + iStart, nBlock);
+			if (nWrite < 0) {
+				perror("Write_to_descriptor_2");
+				return false;
+			}
+		}
     }
 
     return true;
@@ -1810,7 +2094,7 @@ bool write_to_descriptor(DESCRIPTOR_DATA *d, char *txt, int length)
     if (d->out_compress)
         return writeCompressed(d, txt, length);
     else
-        return write_to_descriptor_2(d->descriptor, txt, length);
+		return write_to_descriptor_2(d, txt, length);
 }
 
 
@@ -2010,9 +2294,12 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 				fOld = true;
 			else
 			{
-			if (wizlock && !IS_IMMORTAL(ch))
+			if (game_settings.wizlock && !IS_IMMORTAL(ch))
 			{
-				write_to_buffer(d, "The game is wizlocked.\n\r", 0);
+				if (!IS_NULLSTR(game_settings.wizlock_msg))
+					write_to_buffer(d, game_settings.wizlock_msg, 0);
+				else
+					write_to_buffer(d, "The game is wizlocked.\n\r", 0);
 				write_to_buffer(d, "You can also check the server status via the '#server-status' channel on discord.\n\r", 0);
 				sprintf(buf, "The game is wizlocked, %s tried to connect from %s.", argument, d->host);
 				log_string(buf);
@@ -2068,9 +2355,12 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 		else
 		{
 			/* New player */
-			if (newlock)
+			if (game_settings.new_acct_lock || game_settings.new_char_lock)
 			{
-				write_to_buffer(d, "The game is newlocked.\n\r", 0);
+				if (game_settings.new_acct_lock)
+					write_to_buffer(d, game_settings.new_acct_lock_msg, 0);
+				else
+					write_to_buffer(d, "New characters are not allowed.\n\r", 0);
 				close_socket(d);
 				return;
 			}
@@ -2082,7 +2372,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 				return;
 			}
 
-			if(port == PORT_ALPHA) newlock = true;	/* Reset the newlock, even if this one fails to do anything...*/
+			if(telnet_port == PORT_ALPHA) newlock = true;	/* Reset the newlock, even if this one fails to do anything...*/
 
 			sprintf(buf, "\n\rDo you want to create a character named %s (Y/N)? ", argument);
 			write_to_buffer(d, buf, 0);
@@ -2094,34 +2384,37 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 	case CON_GET_OLD_PASSWORD:
 		write_to_buffer(d, "\n\r", 2);
 
-		if (d->login_attempts > 2)
+		if (d->login_attempts >= game_settings.max_login_attempts)
 		{
 			write_to_buffer(d, "Too many login attempts. Goodbye.\n\r", 0);
 			close_socket(d);
 			return;
 		}
 
-		if(!strcmp(argument, "resetpassword"))
-			{
-				if (ch->pcdata->reset_state == RESET_PENDING)
+		if (game_settings.enable_email)
+		{
+			if(!strcmp(argument, "resetpassword"))
 				{
-					write_to_buffer(d, "You have already requested a password reset. Please enter the reset code.\n\r", 0);
-					d->connected = CON_GET_OLD_PASSWORD;
-					return;
-				}
-				else
-				{
-					if (ch->pcdata->email[0] == '\0')
+					if (ch->pcdata->reset_state == RESET_PENDING)
 					{
-						write_to_buffer(d, "You must have an email address set to reset your password. Please reach out to staff for a manual reset.\n\r", 0);
+						write_to_buffer(d, "You have already requested a password reset. Please enter the reset code.\n\r", 0);
 						d->connected = CON_GET_OLD_PASSWORD;
 						return;
 					}
 					else
 					{
-						write_to_buffer(d, "Please confirm your email address: \n\r", 0);
-						d->connected = CON_CONFIRM_EMAIL_FOR_RESET;
-						return;
+						if (ch->pcdata->email[0] == '\0')
+						{
+							write_to_buffer(d, "You must have an email address set to reset your password. Please reach out to staff for a manual reset.\n\r", 0);
+							d->connected = CON_GET_OLD_PASSWORD;
+							return;
+						}
+						else
+						{
+							write_to_buffer(d, "Please confirm your email address: \n\r", 0);
+							d->connected = CON_CONFIRM_EMAIL_FOR_RESET;
+							return;
+						}
 					}
 
 				}
@@ -2170,7 +2463,10 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 					ch->name, d->host);
 					log_string(log_buf);
 					wiznet(log_buf,NULL,NULL,WIZ_LOGINS,0,get_trust(ch));
-					write_to_buffer(d, "Wrong password. Please try again, or use 'resetpassword' to attempt a reset.\n\r", 0);
+					if (game_settings.enable_email)
+						write_to_buffer(d, "Wrong password. Please try again, or use 'resetpassword' to attempt a reset.\n\r", 0);
+					else
+						write_to_buffer(d, "Wrong password. Please try again or reach out to staff for assistance.\n\r", 0);
 					d->login_attempts++;
 					d->connected = CON_GET_OLD_PASSWORD;
 					return;
@@ -2186,11 +2482,21 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 				ch->name, d->host);
 				log_string(log_buf);
 				wiznet(log_buf,NULL,NULL,WIZ_LOGINS,0,get_trust(ch));
-				write_to_buffer(d, "Wrong password. Please try again, or use 'resetpassword' to attempt a reset.\n\r", 0);
+				if (game_settings.enable_email)
+					write_to_buffer(d, "Wrong password. Please try again, or use 'resetpassword' to attempt a reset.\n\r", 0);
+				else
+					write_to_buffer(d, "Wrong password. Please try again or reach out to staff for assistance.\n\r", 0);
 				d->login_attempts++;
 				d->connected = CON_GET_OLD_PASSWORD;
 				return;
 			}
+		}
+
+		if (!IS_NULLSTR(ch->pcdata->mfa_key) && ch->pcdata->mfa_enabled)
+		{
+			send_to_char("\n\rPlease enter your MFA code: ", ch);
+			d->connected = CON_GET_MFA;
+			return;
 		}
 
 
@@ -2219,8 +2525,8 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
         if (ch->pcdata->need_change_pw == true || ch->pcdata->pwd_vers < 1) {
 	        send_to_char("\n\rYou are required to set a new password. Please do so now.\n\r",ch);
 	        d->connected = CON_CHANGE_PASSWORD;
-	        return;
-        }
+			return;
+		}
 		if (IS_IMMORTAL(ch))
 		{
 			send_to_char("{BWelcome, Immortal.{x\n\r\n\r", ch);
@@ -2240,6 +2546,52 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 			d->connected = CON_READ_MOTD;
 		}
 
+		break;
+
+		case CON_GET_MFA:
+		if (check_mfa(ch, argument))
+		{
+
+			if (check_playing(d,ch->name))
+			return;
+
+			if (check_reconnect(d, ch->name, true))
+			return;
+			
+			if (IS_IMMORTAL(ch))
+			{
+				send_to_char("{BWelcome, Immortal.{x\n\r\n\r", ch);
+				do_function(ch, &do_imotd, "");
+				if(IS_IMPLEMENTOR(ch)) 
+				{
+					if(game_settings.wizlock) 
+						send_to_char("\n\r{b-{B==={C=={W[ {YWIZLOCK ACTIVE{W ]{C=={B==={b-{x\n\r", ch);
+					if(game_settings.new_acct_lock || game_settings.new_char_lock) 
+						send_to_char("\n\r{b-{B==={C=={W[ {GNEWLOCK ACTIVE{W ]{C=={B==={b-{x\n\r", ch);
+				}
+				send_to_char("\n\r{WCurrent active projects:{x\n\r", ch);
+				do_function(ch, &do_project, "list open");
+				send_to_char("[Hit Return to continue]\n\r", ch);
+				d->connected = CON_READ_IMOTD;
+			}
+			else
+			{
+				do_function(ch, &do_motd, "");
+				d->connected = CON_READ_MOTD;
+			}
+		}
+		else
+		{
+			if (d->login_attempts > 2)
+			{
+				write_to_buffer(d, "Too many attempts. Please try again later.\n\r", 0);
+				close_socket(d);
+				return;
+			}
+			d->login_attempts++;
+			d->connected = CON_GET_MFA;
+			return;
+		}
 		break;
 
 	case CON_CONFIRM_EMAIL_FOR_RESET:
@@ -2284,7 +2636,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 				sprintf(reset_subject, "Password Reset for %s", d->character->name);
 				sprintf(reset_msg, "Your password reset code is: %s.\nPlease note that this code will expire after 24 hours.\n\r", d->character->pcdata->reset_code);
 
-				send_email_async(d->character, d->character->pcdata->email, reset_subject, reset_msg);
+				send_email_async(d->character, d->character->pcdata->email, reset_subject, reset_msg, NULL, NULL);
 				d->connected = CON_GET_OLD_PASSWORD;
 				return;
 			}

--- a/db.c
+++ b/db.c
@@ -721,6 +721,16 @@ void fix_dungeonprogs(void);
 
 bool persist_load(void);
 
+void init_string_space()
+{
+	if ((string_space = calloc(1, MAX_STRING)) == NULL)
+	{
+	    bug("Boot_db: can't alloc %d string space.", MAX_STRING);
+	    exit(1);
+	}
+	top_string	= string_space;
+}
+
 /* Top-level booting function*/
 void boot_db(void)
 {

--- a/handler.c
+++ b/handler.c
@@ -39,6 +39,8 @@
 #include <stdlib.h>
 #include <time.h>
 #include <math.h>
+#include <libpng/png.h>
+#include <qrencode.h>
 #include "merc.h"
 #include "interp.h"
 #include "magic.h"
@@ -46,6 +48,7 @@
 #include "tables.h"
 #include "scripts.h"
 #include "wilds.h"
+#include "openssl/evp.h"
 
 extern LLIST *loaded_instances;
 
@@ -8312,93 +8315,113 @@ bool list_appendlist(LLIST *lp, LLIST *src)
 
 bool list_movelink(LLIST *lp, int from, int to)
 {
-	LLIST_LINK *old, *link, *new_link;
+    LLIST_LINK *old, *link, *new_link;
 
-	if( from < 0 ) from = lp->size + from + 1;
-	if( to < 0 ) to = lp->size + to + 1;
+    // Adjust negative indices
+    if (from < 0) from = lp->size + from + 1;
+    if (to < 0) to = lp->size + to + 1;
 
-	if( !from || !to ) return false;
+    // Check for invalid positions
+    if (from <= 0 || to <= 0 || from > lp->size || to > lp->size) return false;
 
-	if( from == to ) return true;	// "Moved" it! :D :D :D :D
+    // If from and to are the same, no need to move
+    if (from == to) return true;
 
-	//if( to > from ) --to;
+    if (lp)
+    {
+        old = NULL;
+        // Locate the 'from' node
+        for (link = lp->head; link && from > 0; link = link->next)
+            if (link->data)
+            {
+                --from;
+                if (!from)
+                {
+                    old = link;
+                    break;
+                }
+            }
 
-	if( lp )
-	{
-		old = NULL;
-		for(link = lp->head; link && from > 0; link = link->next)
-			if(link->data)
-			{
-				--from;
-				if( !from )
-				{
-					old = link;
-					break;
-				}
-			}
+        if (!old) return false;
 
-		if( !old )
-			return false;
+        // Locate the 'to' position
+        for (link = lp->head; link && to > 0; link = link->next)
+        {
+            if (link != old)
+            {
+                if ((to == 1) && (!link->data))
+                {
+                    // This is an empty link, reuse it
+                    link->data = old->data;
+                    old->data = NULL;
+                    return true;
+                }
 
-		for(link = lp->head; link && to > 0; link = link->next )
-		{
-			if(link != old)
-			{
-				if( (to == 1) && (!link->data) )
-				{
-					// This is an empty link, reuse it
-					link->data = old->data;
-					old->data = NULL;
-					return true;
-				}
+                if (link->data)
+                {
+                    if (!--to)
+                    {
+                        new_link = alloc_mem(sizeof(LLIST_LINK));
+                        if (!new_link) return false;
 
-				if( link->data )
-				{
-					if( !--to )
-					{
-						new_link = alloc_mem(sizeof(LLIST_LINK));
-						if( !new_link )
-							return false;
+                        new_link->data = old->data;
+                        old->data = NULL;
 
-						new_link->data = old->data;
-						old->data = NULL;
+                        if (link->prev)
+                        {
+                            new_link->next = link;
+                            new_link->prev = link->prev;
+                            link->prev->next = new_link;
+                            link->prev = new_link;
+                        }
+                        else
+                        {
+                            new_link->next = lp->head;
+                            lp->head->prev = new_link;
+                            lp->head = new_link;
+                            new_link->prev = NULL;
+                        }
 
-						if( link->prev )
-						{
-							new_link->next = link;
-							link->prev->next = new_link;
-							link->prev = new_link;
-						}
-						else
-						{
-							new_link->next = lp->head;
-							lp->head = new_link;
-							new_link->prev = NULL;
-						}
+                        // Update list size
+                        lp->size++;
+                        return true;
+                    }
+                }
+            }
+        }
 
-						return true;
-					}
-				}
-			}
-		}
+        if (to > 0)
+        {
+            // Needs to append if it's at the end
+            link = alloc_mem(sizeof(LLIST_LINK));
+            if (!link) return false;
 
-		if( to > 0 )
-		{
-			// Needs to append if it's at the end
-			link = alloc_mem(sizeof(LLIST_LINK));
-			if( !link )
-				return false;
+            if (!lp->head)
+                lp->head = link;
+            else
+                lp->tail->next = link;
+            link->prev = lp->tail;
+            lp->tail = link;
 
-			if( !lp->head )
-				lp->head = link;
-			else
-				lp->tail->next = link;
-			link->prev = lp->tail;
-			lp->tail = link;
+            link->data = old->data;
+            old->data = NULL;
 
-			link->data = old->data;
-			old->data = NULL;
-		}
+            // Update list size
+            lp->size++;
+        }
+
+        // Update head and tail if necessary
+        if (old == lp->head) lp->head = old->next;
+        if (old == lp->tail) lp->tail = old->prev;
+
+        // Remove old link from its current position
+        if (old->prev) old->prev->next = old->next;
+        if (old->next) old->next->prev = old->prev;
+
+        free(old);
+
+        // Update list size
+        lp->size--;
 	}
 
 	return false;
@@ -9828,14 +9851,14 @@ bool check_social_status(CHAR_DATA *ch)
 	return false;
 }
 
-void send_email(CHAR_DATA *ch, char *email, char *subject, char *message)
+void send_email(CHAR_DATA *ch, char *email, char *subject, char *message , char *attachment_filename, char *attachment_mime_type)
 {
 	char buf[MSL];
 	char subj_buf[256];
 	char body_buf[MSL*2];
 	char body_buf_html[MSL*5];
 
-	extern GLOBAL_DATA gconfig;
+	extern GAME_SETTINGS_DATA game_settings;
 
 
 	quickmail_initialize();
@@ -9845,7 +9868,7 @@ void send_email(CHAR_DATA *ch, char *email, char *subject, char *message)
 	else
 		sprintf(subj_buf, "Email from SentienceMUD");
 
-	quickmail mailobj = quickmail_create(gconfig.email_from_name, gconfig.email_from_addr, subj_buf);
+	quickmail mailobj = quickmail_create(game_settings.email_from_name, game_settings.email_from_addr, subj_buf);
 
 	quickmail_add_to(mailobj, email);
 
@@ -9859,9 +9882,14 @@ void send_email(CHAR_DATA *ch, char *email, char *subject, char *message)
 	quickmail_set_body(mailobj, body_buf);
 	quickmail_add_body_memory(mailobj, "text/html", body_buf_html, strlen(body_buf_html), 0);
 
+
+	if (attachment_filename && attachment_mime_type) {
+		quickmail_add_attachment_file(mailobj, attachment_filename, attachment_mime_type);
+	}
+
 	const char* errmsg;
 
-	if ((errmsg = quickmail_send(mailobj, gconfig.email_host, gconfig.email_port, gconfig.email_username, gconfig.email_password)) != NULL)
+	if ((errmsg = quickmail_send(mailobj, game_settings.email_host, game_settings.email_port, game_settings.email_username, game_settings.email_password)) != NULL)
     	fprintf(stderr, "Error sending e-mail: %s\n", errmsg);
   	quickmail_destroy(mailobj);
   	quickmail_cleanup();
@@ -9905,29 +9933,35 @@ struct EmailData {
     char *email;
     char *subject;
     char *message;
+	char *attachment_filename;
+	char *attachment_mime_type;
 };
 
 // Function executed by the email thread
 void *send_email_thread(void *arg) {
     struct EmailData *emailData = (struct EmailData *)arg;
 
-	send_email(emailData->ch, emailData->email, emailData->subject, emailData->message);
+	send_email(emailData->ch, emailData->email, emailData->subject, emailData->message, emailData->attachment_filename, emailData->attachment_mime_type);
 
     // Clean up and exit the thread
     free(emailData->subject);
     free(emailData->message);
+	free(emailData->attachment_filename);
+	free(emailData->attachment_mime_type);
     free(emailData);
     pthread_exit(NULL);
 }
 
 // Function to send an email asynchronously
-void send_email_async(CHAR_DATA *ch, char *email, char *subject, char *message) {
+void send_email_async(CHAR_DATA *ch, char *email, char *subject, char *message , char *attachment_filename, char *attachment_mime_type) {
     // Allocate memory for the email data
     struct EmailData *emailData = (struct EmailData *)malloc(sizeof(struct EmailData));
     emailData->ch = ch;
     emailData->email = email;
     emailData->subject = strdup(subject); // Duplicate the subject string
     emailData->message = strdup(message); // Duplicate the message string
+    emailData->attachment_filename = attachment_filename ? strdup(attachment_filename) : NULL;
+    emailData->attachment_mime_type = attachment_mime_type ? strdup(attachment_mime_type) : NULL;
 
     // Create a new thread for email dispatching
     pthread_t emailThread;
@@ -9959,6 +9993,101 @@ void generate_reset_code(char* str, int str_len) {
     }
     str--; // Move back to the last character
     *str = '\0'; // Add the null character at the end
+}
+
+char *sha256_crypt(const char *pwd) {
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
+    static char output[65];
+    unsigned char sha256sum[32];
+    unsigned int j;
+
+    if (context == NULL) {
+        return NULL; // Handle error
+    }
+
+    if (EVP_DigestInit_ex(context, EVP_sha256(), NULL) != 1) {
+        EVP_MD_CTX_free(context);
+        return NULL; // Handle error
+    }
+
+    if (EVP_DigestUpdate(context, pwd, strlen(pwd)) != 1) {
+        EVP_MD_CTX_free(context);
+        return NULL; // Handle error
+    }
+
+    if (EVP_DigestFinal_ex(context, sha256sum, NULL) != 1) {
+        EVP_MD_CTX_free(context);
+        return NULL; // Handle error
+    }
+
+    for (j = 0; j < 32; ++j) {
+        snprintf(output + j * 2, 3, "%02x", sha256sum[j]);
+    }
+
+    EVP_MD_CTX_free(context);
+    return output;
+}
+
+void save_qr_code_as_png(QRcode *qrcode, const char *filename, int scale_factor) {
+    int scaled_width = qrcode->width * scale_factor;
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        perror("fopen");
+        return;
+    }
+
+    png_structp png = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    if (!png) {
+        fclose(fp);
+        return;
+    }
+
+    png_infop info = png_create_info_struct(png);
+    if (!info) {
+        png_destroy_write_struct(&png, NULL);
+        fclose(fp);
+        return;
+    }
+
+    if (setjmp(png_jmpbuf(png))) {
+        png_destroy_write_struct(&png, &info);
+        fclose(fp);
+        return;
+    }
+
+    png_init_io(png, fp);
+
+    png_set_IHDR(
+        png,
+        info,
+        scaled_width,
+        scaled_width,
+        8,
+        PNG_COLOR_TYPE_GRAY,
+        PNG_INTERLACE_NONE,
+        PNG_COMPRESSION_TYPE_DEFAULT,
+        PNG_FILTER_TYPE_DEFAULT
+    );
+
+    png_write_info(png, info);
+
+    for (int y = 0; y < qrcode->width; y++) {
+        for (int sy = 0; sy < scale_factor; sy++) {
+            png_bytep row = (png_bytep)malloc(scaled_width * sizeof(png_byte));
+            for (int x = 0; x < qrcode->width; x++) {
+                png_byte pixel = (qrcode->data[y * qrcode->width + x] & 1) ? 0 : 255;
+                for (int sx = 0; sx < scale_factor; sx++) {
+                    row[x * scale_factor + sx] = pixel;
+                }
+            }
+            png_write_row(png, row);
+            free(row);
+        }
+    }
+
+    png_write_end(png, NULL);
+    png_destroy_write_struct(&png, &info);
+    fclose(fp);
 }
 
 void generate_discord_who() {

--- a/interp.c
+++ b/interp.c
@@ -967,6 +967,28 @@ void interpret( CHAR_DATA *ch, char *argument )
 	}
     }
 
+	if (!IS_NPC(ch) && ch->pcdata->mfa_question)
+	{
+		if (command[0] != '\0')
+		{
+			    // Validate the MFA code
+        		if (check_mfa(ch, command)) {
+            		ch->pcdata->mfa_enabled = true;
+					ch->pcdata->qr_code_expiration = 0;
+            		send_to_char("Your MFA key has been validated and enabled.\n\r", ch);
+        		} else {
+            		send_to_char("The code you provided is incorrect. Please try '2fa confirm' again.\n\r", ch);
+        		}
+				ch->pcdata->mfa_question = false;
+				return;
+		}
+		else
+		{
+			send_to_char("{YEnter your MFA code:{x ", ch);
+			return;
+		}
+	}
+
     if (!IS_NPC(ch) && ch->pcdata->inquiry_subject != NULL) {
 	if (command[0] != '\0') {
 	    sprintf(buf, "%s %s", command, argument);

--- a/interp.h
+++ b/interp.h
@@ -618,3 +618,5 @@ DECLARE_DO_FUN( do_cmdshow );
 DECLARE_DO_FUN( do_testemail );
 DECLARE_DO_FUN( do_pwreset );
 DECLARE_DO_FUN( do_lvlaudit );
+DECLARE_DO_FUN( do_keygen );
+DECLARE_DO_FUN ( do_mfareset );

--- a/mccp.c
+++ b/mccp.c
@@ -147,7 +147,24 @@ bool processCompressed(DESCRIPTOR_DATA *desc)
         for (iStart = 0; iStart < len; iStart += nWrite)
         {
             nBlock = UMIN (len - iStart, 4096);
-            if ((nWrite = write (desc->descriptor, desc->out_compress_buf + iStart, nBlock)) < 0)
+            if (desc->ssl) {
+                // If SSL is enabled, encrypt the data
+                nWrite = SSL_write(desc->ssl, desc->out_compress_buf + iStart, nBlock);
+                if (nWrite <= 0) {
+                    int err = SSL_get_error(desc->ssl, nWrite);
+                    if (err == SSL_ERROR_WANT_WRITE) {
+                        // The operation did not complete; the same I/O function should be called again later
+                        break;
+                    } else {
+                        fprintf(stderr, "SSL_write failed with error: %d\n", err);
+                        ERR_print_errors_fp(stderr);
+                        return false;
+                    }
+                }
+            } else {
+                // If SSL is not enabled, send the data as is
+                nWrite = write (desc->descriptor, desc->out_compress_buf + iStart, nBlock);
+                if (nWrite < 0)
             {
 #ifdef ENOSR
                 if (errno == EAGAIN || errno == ENOSR)
@@ -161,6 +178,7 @@ bool processCompressed(DESCRIPTOR_DATA *desc)
 
             if (nWrite <= 0)
                 break;
+            }
         }
 
         if (iStart) {

--- a/merc.h
+++ b/merc.h
@@ -58,8 +58,12 @@
 #include <stdint.h>
 #include <quickmail.h>
 #include <pthread.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <libpng/png.h>
+#include <qrencode.h>
 #include "protocol.h"
-#include "sha256.h"
+
 
 #define STR_HELPER(x) #x
 #define __STR(x) STR_HELPER(x)
@@ -289,6 +293,7 @@ typedef struct	exit_data		EXIT_DATA;
 typedef struct	destination_data	DESTINATION_DATA;
 typedef struct	extra_descr_data	EXTRA_DESCR_DATA;
 typedef struct	global_data		GLOBAL_DATA;
+typedef struct  game_settings_data   GAME_SETTINGS_DATA;
 typedef struct	help_category		HELP_CATEGORY;
 typedef struct	help_data		HELP_DATA;
 typedef struct	mob_index_data		MOB_INDEX_DATA;
@@ -1096,6 +1101,199 @@ struct global_data
     long	db_version;
 };
 
+struct game_settings_data
+{
+    /* Email Settings */
+    bool    enable_email;
+    char    *email_username;                // The username for the email account.
+    char    *email_password;                // The password for the email account.
+    char    *email_host;                    // The hostname of the email server.
+    int     email_port;                     // The port that the email server is listening on.
+    char    *email_from_addr;               // The email address that will appear in the 'from' field of emails sent by the game.
+    char    *email_from_name;               // The name that will appear in the 'from' field of emails sent by the game.
+
+    /* Mission Settings */
+    int     max_quest_allowance;          // How many mission allowances can a player have?
+    int     inc_quests;                   // How many missions will a player accrue when their mission allowance ticks over?
+    int     max_quests;                   // How many missions can a player have running at the same time?
+
+    /* Global Settings */
+    char    *game_name;                     // Name of the game, used in MSSP.
+    char    *login_string;                  // Login string to present on connection.
+    char    *server_description;            // Description of server, eg. "2.0 Public Test Server"
+    bool    testport;                       // Is this a testport?
+    bool    wizlock;                        // Deny non-staff character logins?
+    char    *wizlock_msg;                   // Message to display to players when they try to login if game is wizlocked.
+    bool    new_acct_lock;                  // Deny making new accounts?
+    char    *new_acct_lock_msg;             // Message to display to players when they try to create a new account if game is new_acct_locked.
+    bool    new_char_lock;                  // Deny making new characters on existing accounts?
+    char    *new_char_lock_msg;             // Message to display to players if they try to create a new character if game is new_char_locked.
+    bool    logall;                         // Log everything?
+    bool    require_email_verification;     // Require email verification for accounts?
+    bool    require_2fa_all;                // Require all accounts to have multifactor auth?
+    bool    require_2fa_staff;              // Require accounts with staff characters to either have mfa at account or character level?
+    bool    require_uniq_pass_staff;        // Require staff characters to have player-level password?
+    bool    allow_multiplay_acct_all;       // Allow multiple characters logged in from one account?
+    bool    allow_multiplay_acct_staff;     // Allow multiple logins from staff accounts? (only if allow_multiplay_account_all is true, and account does not have deny_multiplay set)
+    bool    allow_multiplay_host_all;       // Allow multiple accounts to be logged in from one host?
+    bool    allow_multiplay_host_staff;     // Allow multiple accounts to be logged in from one host if one is staff?
+    int     max_login_attempts;             // How many login attempts are allowed before disconnecting?
+    int     idle_time;                      // How many ticks until a user is considered idle?
+    int     idle_disconnect_time;           // How many ticks until an idle user is disconnected?
+    int     max_alias;                      // How many aliases can a player have?
+    int     max_characters;                 // How many characters can a player have (can be overridden by account data);
+    int     max_churches;                       // How many organizations can exist?
+    bool    enable_telnet;                  // Do we allow plaintext?
+    int     telnet_port;                    // Plaintext telnet port.
+    bool    enable_tls;                     // Do we allow tls connections?
+    int     tls_port;                       // TLS port.
+//    bool    enable_websocket_plain;         // Do we allow websocket connections?
+//    int     websocket_port;                 // Websocket port.
+//    bool    enable_websocket_tls;           // Do we allow tls websocket connections?
+//    int     websocket_tls_port;             // TLS websocket port.
+//    bool    enable_web;                     // Do we allow web connections?
+    char    *ssl_cert_path;                      // Path to SSL certificate.
+    char    *ssl_key_path;                       // Path to SSL key.
+    bool    enable_insecure_warning;               // Do we show a warning for insecure connections?
+    char    *insecure_warning_msg;          // What message do we display for insecure users? (requires insecure_warning)
+    int     max_logfile_size;               // What size do we start rotating logs at (in MB)?
+    /* MSSP Settings */
+    int mssp_players;                            // Automatically updated by the game.
+    int mssp_uptime;                             // Automatically updated by the game.
+    int mssp_crawl_delay;                        // How often do we want crawlers to come back? -1 for crawler default. Recommended values: -1, 1, 5, 11, 23
+    char *mssp_hostname;                         // Server hostname
+    int mssp_port;                               // Server Port
+    int mssp_tls_port;                           // TLS Server Port
+    char *mssp_codebase;                         // Name of the codebase, eg Merc 2.1. You can report multiple codebases using the array format, make sure to report the current codebase last.
+    char *mssp_contact;                          // Email address for contacting the mud.
+    int mssp_created;                            // Year the MUD was created.
+    char *mssp_ip;                               // Current or new IP address.
+    char *mssp_language;                         // English name of the language used, eg German or English
+    char *mssp_location;                         // English short name of the country where the server is located, using ISO 3166.
+    int mssp_minimum_age;                        // Current minimum age requirement, omit if not applicable.
+    char *mssp_website;                          // URL to MUD website, this should include the http:// or https:// prefix.
+    char *mssp_family;                           // AberMUD, CoffeeMUD, DikuMUD, Evennia, LPMud, MajorMUD, MOO, Mordor, SocketMud, TinyMUD, TinyMUCK, TinyMUSH, Custom. Report Custom unless it's a well established family. You can report multiple generic codebases using the array format, make sure to report the most distant codebase (aka the family) last. Check the MUD family tree for naming and capitalization.
+    char *mssp_genre;                            // Adult, Fantasy, Historical, Horror, Modern, Mystery, None, Romance, Science Fiction, Spiritual
+    char *mssp_status;                           // Alpha, Closed Beta, Open Beta, Live
+    char *mssp_gamesystem;                       // D&D, d20 System, World of Darkness, Etc.
+    char *mssp_intermud;                         // AberChat, I3, IMC2, MudNet, Etc. Can be used multiple times if you support several protocols, most important protocol last. Leave empty or omit if no Intermud protocol is supported.
+    char *mssp_subgenre;                         //Alternate History, Anime, Cyberpunk, Detective, Discworld, Dragonlance, Christian Fiction, Classical Fantasy, Crime, Dark Fantasy, Epic Fantasy, Erotic, Exploration, Forgotten Realms, Frankenstein, Gothic, High Fantasy, Magical Realism, Medieval Fantasy, Multiverse, Paranormal, Post-Apocalyptic, Military Science Fiction, Mythology, Pulp, Star Wars, Steampunk, Suspense, Time Travel, Weird Fiction, World War II, Urban Fantasy, Etc.
+    char *mssp_discord_server;                   // URL to a Discord server, this should include the https:// prefix.
+    int mssp_areas;                              // Current number of areas (open only? let mud generate?)
+    int mssp_helpfiles;                          // Current number of helpfiles (player-only? let mud generate?)
+    int mssp_mobiles;                            // Current number of unique mobs (open areas only?)
+    int mssp_objects;                            // Current number of unique objects (open areas only? non-immortal?)
+    int mssp_rooms;                              // Current number of unique rooms (open areas only?)
+    int mssp_classes;                            // Number of player classes, use 0 if classless.
+    int mssp_levels;                             // Number of player levels, use 0 if level-less.
+    int mssp_races;                              // Number of player races, use 0 if raceless.
+    int mssp_skills;                             // Number of player skills, use 0 if skill-less.
+    int mssp_dbsize;                             //
+
+    bool mssp_ansi;                              // ANSI color code support?
+    bool mssp_gmcp;                              // GMCP (Generic Mud Communication Protocol) support? 
+    bool mssp_mccp;                              // MCCP (Mud Client Compression Protocol 2) support?
+    bool mssp_mcp;                               // MCP support?
+    bool mssp_msdp;                              // MSDP support?
+    bool mssp_msp;                               // MSP (Mud Sound Protocol) support?
+    bool mssp_mxp;                               // MXP (Mud eXtension Protocol) support?
+    bool mssp_pueb;                              // Pueblo/UE support?
+    bool mssp_utf8;                              // UTF-8 support?
+    bool mssp_vt100;                             // VT100 support?
+    bool mssp_xterm256;                          // 256 color support?
+    bool mssp_xtermtrue;                         // True color support?
+    bool mssp_atcp;                              // ATCP (Achaea Telnet Client Protocol) support?
+    bool mssp_ssl;                               // SSL support?
+    bool mssp_pay2play;                          // Pay to play?
+    bool mssp_pay4perks;                         // Pay for perks?
+    bool mssp_hiring_builders;                   // Looking for builders?
+    bool mssp_hiring_coders;                     // Looking for coders?
+    bool mssp_adult_material;                    // Does MUD contain mature content?
+    bool mssp_multiclass;                        // Multiclassing allowed?
+    bool mssp_newbie_friendly;                   // Newbie friendly?
+    bool mssp_player_cities;                     // Player cities?
+    bool mssp_player_clans;                      // Player clans?
+    bool mssp_player_crafting;                   // Player crafting?
+    bool mssp_player_guilds;                     // Player guilds?
+    char *mssp_equipment_system;                 // Equipment system, eg. Diku, ROM, SMAUG, etc.
+    char *mssp_multiplaying;                     // Multiplaying allowed?
+    bool mssp_playerkilling;                     // Player killing allowed?
+    bool mssp_quest_system;                      // Quest system?
+    bool mssp_roleplaying;                       // Roleplaying enforced?
+    bool mssp_training_system;                   // Training system?
+    bool mssp_world_originality;                 // Based on an established setting?
+};
+/*
+struct mssp_data
+{
+    // MSSP Settings
+    int mssp_players;                            // Automatically updated by the game.
+    int mssp_uptime;                             // Automatically updated by the game.
+    int mssp_crawl_delay;                        // How often do we want crawlers to come back? -1 for crawler default. Recommended values: -1, 1, 5, 11, 23
+    char *mssp_hostname;                         // Server hostname
+    int mssp_port;                               // Server Port
+    int mssp_tls_port;                           // TLS Server Port
+    char *mssp_codebase;                         // Name of the codebase, eg Merc 2.1. You can report multiple codebases using the array format, make sure to report the current codebase last.
+    char *mssp_contact;                          // Email address for contacting the mud.
+    int mssp_created;                            // Year the MUD was created.
+    char *mssp_ip;                               // Current or new IP address.
+    char *mssp_language;                         // English name of the language used, eg German or English
+    char *mssp_location;                         // English short name of the country where the server is located, using ISO 3166.
+    int mssp_minimum_age;                        // Current minimum age requirement, omit if not applicable.
+    char *mssp_website;                          // URL to MUD website, this should include the http:// or https:// prefix.
+    char *mssp_family;                           // AberMUD, CoffeeMUD, DikuMUD, Evennia, LPMud, MajorMUD, MOO, Mordor, SocketMud, TinyMUD, TinyMUCK, TinyMUSH, Custom. Report Custom unless it's a well established family. You can report multiple generic codebases using the array format, make sure to report the most distant codebase (aka the family) last. Check the MUD family tree for naming and capitalization.
+    char *mssp_genre;                            // Adult, Fantasy, Historical, Horror, Modern, Mystery, None, Romance, Science Fiction, Spiritual
+    char *mssp_status;                           // Alpha, Closed Beta, Open Beta, Live
+    char *mssp_gamesystem;                       // D&D, d20 System, World of Darkness, Etc.
+    char *mssp_intermud;                         // AberChat, I3, IMC2, MudNet, Etc. Can be used multiple times if you support several protocols, most important protocol last. Leave empty or omit if no Intermud protocol is supported.
+    char *mssp_subgenre;                         //Alternate History, Anime, Cyberpunk, Detective, Discworld, Dragonlance, Christian Fiction, Classical Fantasy, Crime, Dark Fantasy, Epic Fantasy, Erotic, Exploration, Forgotten Realms, Frankenstein, Gothic, High Fantasy, Magical Realism, Medieval Fantasy, Multiverse, Paranormal, Post-Apocalyptic, Military Science Fiction, Mythology, Pulp, Star Wars, Steampunk, Suspense, Time Travel, Weird Fiction, World War II, Urban Fantasy, Etc.
+    char *mssp_discord_server;                   // URL to a Discord server, this should include the https:// prefix.
+    int mssp_areas;                              // Current number of areas (open only? let mud generate?)
+    int mssp_helpfiles;                          // Current number of helpfiles (player-only? let mud generate?)
+    int mssp_mobiles;                            // Current number of unique mobs (open areas only?)
+    int mssp_objects;                            // Current number of unique objects (open areas only? non-immortal?)
+    int mssp_rooms;                              // Current number of unique rooms (open areas only?)
+    int mssp_classes;                            // Number of player classes, use 0 if classless.
+    int mssp_levels;                             // Number of player levels, use 0 if level-less.
+    int mssp_races;                              // Number of player races, use 0 if raceless.
+    int mssp_skills;                             // Number of player skills, use 0 if skill-less.
+    int mssp_dbsize;                             //
+
+    bool mssp_ansi;                              // ANSI color code support?
+    bool mssp_gmcp;                              // GMCP (Generic Mud Communication Protocol) support? 
+    bool mssp_mccp;                              // MCCP (Mud Client Compression Protocol 2) support?
+    bool mssp_mcp;                               // MCP support?
+    bool mssp_msdp;                              // MSDP support?
+    bool mssp_msp;                               // MSP (Mud Sound Protocol) support?
+    bool mssp_mxp;                               // MXP (Mud eXtension Protocol) support?
+    bool mssp_pueb;                              // Pueblo/UE support?
+    bool mssp_utf8;                              // UTF-8 support?
+    bool mssp_vt100;                             // VT100 support?
+    bool mssp_xterm256;                          // 256 color support?
+    bool mssp_xtermtrue;                         // True color support?
+    bool mssp_atcp;                              // ATCP (Achaea Telnet Client Protocol) support?
+    bool mssp_ssl;                               // SSL support?
+    bool mssp_pay2play;                          // Pay to play?
+    bool mssp_pay4perks;                         // Pay for perks?
+    bool mssp_hiring_builders;                   // Looking for builders?
+    bool mssp_hiring_coders;                     // Looking for coders?
+    bool mssp_adult_material;                    // Does MUD contain mature content?
+    bool mssp_multiclass;                        // Multiclassing allowed?
+    bool mssp_newbie_friendly;                   // Newbie friendly?
+    bool mssp_player_cities;                     // Player cities?
+    bool mssp_player_clans;                      // Player clans?
+    bool mssp_player_crafting;                   // Player crafting?
+    bool mssp_player_guilds;                     // Player guilds?
+    char *mssp_equipment_system;                 // Equipment system, eg. Diku, ROM, SMAUG, etc.
+    char *mssp_multiplaying;                     // Multiplaying allowed?
+    bool mssp_playerkilling;                     // Player killing allowed?
+    bool mssp_quest_system;                      // Quest system?
+    bool mssp_roleplaying;                       // Roleplaying enforced?
+    bool mssp_training_system;                   // Training system?
+    bool mssp_world_originality;                 // Based on an established setting?
+};
+*/
+
 struct bounty_data
 {
     char *name;
@@ -1245,6 +1443,7 @@ struct church_treasure_room_data
 #define CON_CHANGE_PASSWORD_CONFIRM     21
 #define CON_GET_EMAIL			22
 #define CON_CONFIRM_EMAIL_FOR_RESET 23
+#define CON_GET_MFA            24
 
 
 /* Places */
@@ -1359,6 +1558,9 @@ struct	descriptor_data
     TOKEN_DATA *	input_tok;
 
     unsigned int		muted;			// All text heading to the output will be blocked
+    bool    tls_handshake_in_progress;
+    SSL *ssl;
+
 
 };
 
@@ -4333,6 +4535,10 @@ struct	pc_data
     time_t		last_logoff;
     time_t		last_login;
     time_t		last_project_inquiry;
+    char *      mfa_key;
+    time_t      qr_code_expiration;
+    bool        mfa_enabled;
+    bool        mfa_question;
 
     int			class_current;
     int			sub_class_current;
@@ -7242,6 +7448,7 @@ extern		IMMORTAL_DATA		*unassigned_immortal_list;
 #define INSTANCES_FILE		WORLD_DIR "instances.dat"
 #define SHIPS_FILE			WORLD_DIR "ships.dat"
 #define COMMANDS_FILE       SYSTEM_DIR "commands.dat"
+#define GAME_SETTINGS_FILE  SYSTEM_DIR "game_settings.dat"
 
 /* POST msg queue */
 #define MSGQUEUE	1111
@@ -7420,6 +7627,8 @@ void reset_obj( OBJ_DATA *obj );
 /* act_wiz.c */
 int gconfig_read(void);
 int gconfig_write(void);
+int game_settings_read(void);
+int game_settings_write(void);
 void do_chset( CHAR_DATA *ch, char *argument );
 void save_shares	args( ( void ) );
 void wiznet(char *string, CHAR_DATA *ch, OBJ_DATA *obj, long flag, long flag_skip, int min_level );
@@ -8008,8 +8217,7 @@ int use_catalyst_here(CHAR_DATA *ch,ROOM_INDEX_DATA *room,int type,int amount,in
 int use_catalyst(CHAR_DATA *ch,ROOM_INDEX_DATA *room,int type,int method,int amount,int min_strength, int max_strength, bool show);
 void move_cart(CHAR_DATA *ch, ROOM_INDEX_DATA *room, bool delay);
 void visit_rooms(ROOM_INDEX_DATA *room, VISIT_FUNC *func, int depth, void *argv[], int argc, bool closed);
-void send_email(CHAR_DATA *ch, char *email, char *subject, char *message);
-void send_email_async(CHAR_DATA *ch, char *email, char *subject, char *message);
+
 void generate_reset_code(char* str, int len);
 
 /* help.c */
@@ -8876,6 +9084,8 @@ char *flagbank_string(const struct flag_type **bank, ...);
 
 void display_resets(CHAR_DATA *ch);
 
+extern GLOBAL_DATA gconfig;
+extern GAME_SETTINGS_DATA game_settings;
 
 extern LLIST *commands_list;
 CMD_DATA *get_cmd_data(char *name);
@@ -8883,6 +9093,18 @@ bool load_commands();
 void save_commands();
 
 bool check_social_status(CHAR_DATA *ch);
+
+void send_email(CHAR_DATA *ch, char *email, char *subject, char *message, char *attachment_filename, char *attachment_mime_type);
+void send_email_async(CHAR_DATA *ch, char *email, char *subject, char *message, char *attachment_filename, char *attachment_mime_type);
+
+void generate_key(CHAR_DATA *ch, char *key);
+bool check_mfa(CHAR_DATA *ch, char *argument);
+char *sha256_crypt( const char *pwd );
+void configure_context(SSL_CTX *ctx);
+SSL_CTX* create_context(void);
+void init_openssl_library(void);
+void save_qr_code_as_png(QRcode *qrcode, const char *filename, int scale_factor);
+
 
 /*
  Introducing some variables to keep compiler from complaining. These are used in do_version.

--- a/olc_mpcode.c
+++ b/olc_mpcode.c
@@ -182,7 +182,7 @@ static int olc_script_typeifc[] = {
 // Testports have reduced security checks
 bool script_security_check(CHAR_DATA *ch)
 {
-	if(port == PORT_NORMAL)
+	if(!game_settings.testport)
 		return (bool)(!IS_NPC(ch) && ch->tot_level >= (MAX_LEVEL-1));
 	else
 		return true;
@@ -190,7 +190,7 @@ bool script_security_check(CHAR_DATA *ch)
 
 bool script_imp_check(CHAR_DATA *ch)
 {
-	if(port == PORT_NORMAL)
+	if(!game_settings.testport)
 		return (bool)(!IS_NPC(ch) && ch->tot_level == MAX_LEVEL);
 	else
 		return (bool)(!IS_NPC(ch) && ch->tot_level >= (MAX_LEVEL-1));

--- a/quest.c
+++ b/quest.c
@@ -390,7 +390,7 @@ void do_quest(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		if (ch->nextquest > 0 && !IS_IMMORTAL(ch) && port != PORT_RAE)
+		if (ch->nextquest > 0 && !IS_IMMORTAL(ch) && game_settings.telnet_port != PORT_RAE)
 		{
 			sprintf(buf, "You're very brave, %s, but let someone else have a chance.", ch->name);
 			if (mob == NULL)

--- a/save.c
+++ b/save.c
@@ -596,6 +596,13 @@ void fwrite_char(CHAR_DATA *ch, FILE *fp)
 		fprintf(fp, "Reset_Time %ld\n", ch->pcdata->reset_time);
 
 	fprintf(fp, "ResetState %d\n", ch->pcdata->reset_state);
+
+	if (ch->pcdata->mfa_key != NULL)
+		fprintf(fp, "MFA_Key %s~\n", ch->pcdata->mfa_key);
+	if (ch->pcdata->qr_code_expiration != 0)
+		fprintf(fp, "MFA_Code_Expiration %ld\n", ch->pcdata->qr_code_expiration);
+	if (ch->pcdata->mfa_enabled == true)
+		fprintf(fp, "MFA_Enabled\n");
 	/*if (ch->pcdata->immortal->bamfin[0] != '\0')
 	    fprintf(fp, "Bin  %s~\n",	ch->pcdata->immortal->bamfin);
 	if (ch->pcdata->immortal->bamfout[0] != '\0')
@@ -757,6 +764,8 @@ bool load_char_obj(DESCRIPTOR_DATA *d, char *name)
     ch->pcdata->condition[COND_STONED]	= 0;
     ch->pcdata->security		= 0;
     ch->pcdata->challenge_delay		= 0;
+	ch->pcdata->mfa_key = str_dup("");
+	ch->pcdata->qr_code_expiration = 0;
     ch->morphed = false;
     ch->locker_rent = 0;
     ch->deathsight_vision = 0;
@@ -1620,6 +1629,12 @@ void fread_char(CHAR_DATA *ch, FILE *fp)
 	    KEY("Mc1",		 ch->pcdata->class_cleric,		fread_number(fp));
 	    KEY("Mc2",		 ch->pcdata->class_thief,		fread_number(fp));
 	    KEY("Mc3",		 ch->pcdata->class_warrior,		fread_number(fp));
+		KEY("MFA_KEY",		ch->pcdata->mfa_key,		fread_string(fp));
+		KEY("MFA_Code_Expiration", ch->pcdata->qr_code_expiration, fread_number(fp));
+		if (!str_cmp(word, "MFA_Enabled"))
+			ch->pcdata->mfa_enabled = true;
+
+
 	    KEY("MonsterKills", ch->monster_kills,	fread_number(fp));
 
 	    /*
@@ -4183,10 +4198,12 @@ void fix_character(CHAR_DATA *ch)
 	}
 
 	if (ch->version < VERSION_PLAYER_007 )
+	{
 		SET_BIT(ch->act[1], PLR_COMPASS);
 		SET_BIT(ch->act[1], PLR_AUTOCAT);
 
 		ch->version = VERSION_PLAYER_007;
+	}
 }
 
 

--- a/script_const.c
+++ b/script_const.c
@@ -465,6 +465,7 @@ ENT_FIELD entity_conn[] = {
 	{"connection",	ENTITY_CONN_CONNECTION,		ENT_NUMBER	},
 	{"snooper",		ENTITY_CONN_SNOOPER,		ENT_CONN	},
 	{"client",		ENTITY_CONN_CLIENT,			ENT_STRING	},
+	{"secure",		ENTITY_CONN_SECURE,			ENT_BOOLEAN },
 	{NULL,		0,			ENT_UNKNOWN	}
 };
 

--- a/script_expand.c
+++ b/script_expand.c
@@ -1079,13 +1079,13 @@ char *expand_entity_game(SCRIPT_VARINFO *info,char *str,SCRIPT_PARAM *arg)
 	case ENTITY_GAME_NAME:
 		arg->type = ENT_STRING;
 		clear_buf(arg->buffer);
-		add_buf(arg->buffer, "Sentience");
+		add_buf(arg->buffer, game_settings.game_name);
 		arg->d.str = buf_string(arg->buffer);
 		break;
 
 	case ENTITY_GAME_PORT:
 		arg->type = ENT_NUMBER;
-		arg->d.num = port;
+		arg->d.num = game_settings.telnet_port;
 		break;
 
 	case ENTITY_GAME_PLAYERS:
@@ -3488,6 +3488,10 @@ char *expand_entity_conn(SCRIPT_VARINFO *info,char *str,SCRIPT_PARAM *arg)
 	case ENTITY_CONN_CLIENT:
 		arg->type = ENT_STRING;
 		arg->d.str = (arg->d.conn && (script_security >= MAX_SCRIPT_SECURITY)) ? arg->d.conn->pProtocol->pVariables[eMSDP_CLIENT_ID]->pValueString : "Unknown";
+		break;
+	case ENTITY_CONN_SECURE:
+		arg->type = ENT_BOOLEAN;
+		arg->d.boolean = (arg->d.conn && (script_security >= MAX_SCRIPT_SECURITY) && arg->d.conn->ssl) ? true : false;
 		break;
 	default: return NULL;
 	}

--- a/scripts.h
+++ b/scripts.h
@@ -943,6 +943,7 @@ enum entity_conn_enum {
 	ENTITY_CONN_CONNECTION,
 	ENTITY_CONN_SNOOPER,
 	ENTITY_CONN_CLIENT,
+	ENTITY_CONN_SECURE,
 };
 
 enum entity_list_enum {

--- a/tables.c
+++ b/tables.c
@@ -3442,4 +3442,6 @@ const struct do_func_type do_func_table[] =
         { "do_testemail",                do_testemail },
         { "do_pwreset",                 do_pwreset  },
         { "do_lvlaudit",                do_lvlaudit },
+        { "do_keygen",                     do_keygen },
+        { "do_mfareset",                do_mfareset },
 };

--- a/tls.c
+++ b/tls.c
@@ -1,0 +1,130 @@
+ /***************************************************************************
+ *  Original Diku Mud copyright (C) 1990, 1991 by Sebastian Hammer,        *
+ *  Michael Seifert, Hans Henrik St{rfeldt, Tom Madsen, and Katja Nyboe.   *
+ *                                                                         *
+ *  Merc Diku Mud improvments copyright (C) 1992, 1993 by Michael          *
+ *  Chastain, Michael Quan, and Mitchell Tse.                              *
+ *                                                                         *
+ *  In order to use any part of this Merc Diku Mud, you must comply with   *
+ *  both the original Diku license in 'license.doc' as well the Merc       *
+ *  license in 'license.txt'.  In particular, you may not remove either of *
+ *  these copyright notices.                                               *
+ *                                                                         *
+ *  Thanks to abaddon for proof-reading our comm.c and pointing out bugs.  *
+ *  Any remaining bugs are, of course, our work, not his.  :)              *
+ *                                                                         *
+ *  Much time and thought has gone into this software and you are          *
+ *  benefitting.  We hope that you share your changes too.  What goes      *
+ *  around, comes around.                                                  *
+ ***************************************************************************/
+
+/***************************************************************************
+*	ROM 2.4 is copyright 1993-1998 Russ Taylor			   *
+*	ROM has been brought to you by the ROM consortium		   *
+*	    Russ Taylor (rtaylor@hypercube.org)				   *
+*	    Gabrielle Taylor (gtaylor@hypercube.org)			   *
+*	    Brian Moore (zump@rom.org)					   *
+*	By using this code, you have agreed to follow the terms of the	   *
+*	ROM license, in the file Rom24/doc/rom.license			   *
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *    Scripting engine rebuilt by Michael Kurtz (Nibelung)                 *
+ *    Used with permission.                                                *
+ *                                                                         *
+ **************************************************************************/
+
+/*
+ * This file contains all of the OS-dependent stuff:
+ *   startup, signals, BSD sockets for tcp/ip, i/o, timing.
+ *
+ * The data flow for input is:
+ *    Game_loop ---> Read_from_descriptor ---> Read
+ *    Game_loop ---> Read_from_buffer
+ *
+ * The data flow for output is:
+ *    Game_loop ---> Process_Output ---> Write_to_descriptor -> Write
+ *
+ * The OS-dependent functions are Read_from_descriptor and Write_to_descriptor.
+ * -- Furey  26 Jan 1993
+ */
+
+ #include <sys/types.h>
+ #include <sys/time.h>
+ #include <ctype.h>
+ #include <errno.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <stdlib.h>
+ #include <signal.h>
+ #include <time.h>
+ #include <zlib.h>
+ /* VIZZWILDS - support for plogf() and printf_to_char() functions*/
+ #include <stdarg.h>
+ #include <openssl/ssl.h>
+ #include <openssl/err.h>
+ 
+ #include "strings.h"
+ #include "merc.h"
+ #include "interp.h"
+ #include "recycle.h"
+ #include "scripts.h"
+ #include "tables.h"
+ #include "wilds.h"
+ #include "protocol.h"
+ 
+ /*
+  * Socket and TCP/IP stuff.
+  */
+ #include <fcntl.h>
+ #include <netdb.h>
+ #include <netinet/in.h>
+ #include <sys/socket.h>
+ #include "telnet.h"
+ 
+ 
+ // Global SSL context
+ SSL_CTX *ctx;
+ 
+ // Function to initialize SSL library
+ void init_openssl_library(void)
+ {
+     SSL_load_error_strings();
+     OpenSSL_add_ssl_algorithms();
+ }
+ 
+ // Function to create a new SSL context
+ SSL_CTX* create_context(void)
+ {
+     const SSL_METHOD *method;
+     SSL_CTX *ctx;
+ 
+     method = SSLv23_server_method();
+ 
+     ctx = SSL_CTX_new(method);
+     if (!ctx) {
+         perror("Unable to create SSL context");
+         ERR_print_errors_fp(stderr);
+         exit(EXIT_FAILURE);
+     }
+ 
+     return ctx;
+ }
+ 
+ // Function to configure SSL context
+ void configure_context(SSL_CTX *ctx)
+ {
+     SSL_CTX_set_ecdh_auto(ctx, 1);
+ 
+     /* Set the key and cert */
+     if (SSL_CTX_use_certificate_file(ctx, game_settings.ssl_cert_path, SSL_FILETYPE_PEM) <= 0) {
+         ERR_print_errors_fp(stderr);
+         exit(EXIT_FAILURE);
+     }
+ 
+     if (SSL_CTX_use_PrivateKey_file(ctx, game_settings.ssl_key_path, SSL_FILETYPE_PEM) <= 0 ) {
+         ERR_print_errors_fp(stderr);
+         exit(EXIT_FAILURE);
+     }
+ }


### PR DESCRIPTION
Backporting multiple features, including but not limited to:

`mfa` command for multifactor auth
TLS support, with warning for using an insecure plaintext port
Moving to a game settings file for things like game name, server description, and other things.
Adds the following to prompt options:

`%+` - Shows server description
`%-` - Shows secure/insecure connection status
`%_` - Shows character name (for people who like to multiplay, you know who you are)

For MFA - The game will display a QR code in the terminal, and will also email it to the email on file for your character.

Note: Due to changes in underlying encryption algo, everyone must reset passwords. This can be done by entering `resetpassword` at the password prompt, and entering your character's email.