### PR TITLE
fix: channel CPU spin and wilderness say unavailable

### DIFF
--- a/channels/channel_service.c
+++ b/channels/channel_service.c
@@ -1091,7 +1091,7 @@ static bool channel_topic_list_add_ref(CHANNEL_SUBSCRIPTION_TOPIC *topics,
         return false;
 
     for (i = 0; i < *topic_count; i++) {
-        if (!str_cmp(topics[i].topic, topic)) {
+        if (strcmp(topics[i].topic, topic) == 0) {
             topics[i].refs++;
             return true;
         }
@@ -1116,7 +1116,7 @@ static int channel_topic_list_find(CHANNEL_SUBSCRIPTION_TOPIC *topics,
         return -1;
 
     for (i = 0; i < topic_count; i++) {
-        if (!str_cmp(topics[i].topic, topic))
+        if (strcmp(topics[i].topic, topic) == 0)
             return i;
     }
 

--- a/channels/channels_common.c
+++ b/channels/channels_common.c
@@ -1,5 +1,6 @@
 #include "../merc.h"
 #include "../tables.h"
+#include "../wilds.h"
 #include "channels_common.h"
 #include "channel_filter.h"
 
@@ -222,7 +223,7 @@ bool channel_build_room_scope_topic(ROOM_INDEX_DATA *room, char *topic_buf, size
         return false;
 
     if (room->wilds) {
-        wilds_uid = room->w;
+        wilds_uid = room->wilds->uid;
         if (wilds_uid <= 0)
             return false;
 


### PR DESCRIPTION
Two bugs fixed:

1. perf: use strcmp for channel topic list comparisons Topic strings are always lowercase ASCII (generated via snprintf from patterns like 'rt:room:v:%d:%d'). Using str_cmp called utf8_getchar + utf8_tolower per character — multiple macro checks plus a unicode table lookup per byte — causing 100% CPU spin when channel_service_sync_subscriptions iterated thousands of loaded NPCs every pulse second. Switching channel_topic_list_add_ref and channel_topic_list_find to strcmp reduces per-comparison cost by ~10-20x. Root cause: GDB trace showed thread 1 spinning in str_cmp <- channel_topic_list_add_ref <- channel_service_sync_subscriptions <- channel_service_pulse <- update_handler.

2. fix: use room->wilds->uid not room->w for wilderness room topics channel_build_room_scope_topic used room->w to get the wilderness UID, but room->w is only populated from file loading (olc_save). At runtime, wilderness rooms have room->wilds set (the live WILDS_DATA pointer) but room->w remains 0, causing channel_build_topic_for_sender to return false and 'say' (and other ROOM_WV-scoped channels) to report 'That channel is currently unavailable.' to players in wilderness rooms. Fix: use room->wilds->uid directly. Add wilds.h include to channels_common.c so WILDS_DATA is a complete type.