### PR TITLE
fix: create SSL context only once across TLS and WSS ports

### DIFF
--- a/comm.c
+++ b/comm.c
@@ -1945,14 +1945,12 @@ int init_tls_socket(int port)
     exit(1);
     }
 
-    // Initialize SSL library
+    // Initialize SSL library (idempotent)
     init_openssl_library();
 
-    // Create SSL context
-    ctx = create_context();
-
-    // Configure SSL context
-    configure_context(ctx);
+    // Create SSL context only once; both TLS and WSS ports share it
+    if (!ctx)
+        ctx = create_context();
 
     return fd;
 }


### PR DESCRIPTION
init_tls_socket was called for both port 9010 (TLS) and port 9020 (WSS), each time calling create_context() which already calls configure_context() internally, then calling configure_context() a second time explicitly.

This caused two bugs:
1. Double configure_context: SSL_CTX_add_extra_chain_cert() appends (not replaces) intermediate CA certs, so the chain had 4 certs instead of 2 after the second call, causing TLS handshake failures in some clients.
2. Context leak: the global ctx was overwritten on the second call, leaking the first SSL_CTX.

Fix: guard ctx creation with 'if (!ctx)' so both ports share one context, and remove the redundant configure_context() call (create_context already handles configuration).