### PR TITLE
fix: remove sha256.c from build to prevent OpenSSL symbol interposition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,6 @@ set(SOURCE_FILES
     scripts.c
     sectors_runtime.c
     secret.c
-    sha256.c
     shoot.c
     skill_data.c
     skill_group.c

--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,6 @@ C_FILES = \
     scripts.c \
     sectors_runtime.c \
     secret.c \
-    sha256.c \
     shoot.c \
     skill_data.c \
     skill_group.c \

--- a/handler.c
+++ b/handler.c
@@ -11156,6 +11156,40 @@ void generate_reset_code(char* str, int str_len) {
     *str = '\0'; // Add the null character at the end
 }
 
+/**
+ * sha256_crypt - Hash a password string using SHA256 via OpenSSL EVP
+ *
+ * Returns a pointer to a static 65-byte buffer containing the lowercase
+ * hex-encoded SHA256 digest of pwd. Not thread-safe (static buffer).
+ *
+ * @param pwd  Plaintext string to hash
+ * @return     Hex string of SHA256 digest, or NULL on EVP failure
+ */
+char *sha256_crypt(const char *pwd)
+{
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    static char output[65];
+    unsigned char digest[32];
+    unsigned int j;
+
+    if (!ctx)
+        return NULL;
+
+    if (EVP_DigestInit_ex(ctx, EVP_sha256(), NULL) != 1 ||
+        EVP_DigestUpdate(ctx, pwd, strlen(pwd)) != 1 ||
+        EVP_DigestFinal_ex(ctx, digest, NULL) != 1) {
+        EVP_MD_CTX_free(ctx);
+        return NULL;
+    }
+
+    EVP_MD_CTX_free(ctx);
+
+    for (j = 0; j < 32; ++j)
+        snprintf(output + j * 2, 3, "%02x", digest[j]);
+
+    return output;
+}
+
 char *tmp_sprintf(const char *fmt, ...)
 {
     static char buf[MAX_STRING_LENGTH];
@@ -12063,8 +12097,6 @@ bool set_encrypted_password(char **target_password_field, int *target_version_fi
 
 // Checks a plaintext password against a stored hash using tiered methods.
 password_check_status check_encrypted_password(const char *plaintext_password, const char *stored_hash, int stored_version) {
-    extern char *sha256_crypt(const char *pwd);  // Forward declaration for SHA256 function
-    
     if (!plaintext_password || !stored_hash || stored_hash[0] == '\0') {
         return PWD_CHECK_FAIL; // Cannot check against empty stored hash
     }

--- a/tests/data/unit/sha256_unit_tests.json
+++ b/tests/data/unit/sha256_unit_tests.json
@@ -1,29 +1,29 @@
 {
   "type": "test_suite",
   "test_suite": "sha256_unit_tests",
-  "description": "Unit tests for custom SHA256 implementation correctness",
+  "description": "Unit tests for sha256_crypt() correctness (backed by OpenSSL EVP)",
   "version": "1.0",
   "requires_mud_environment": false,
   "test_level": "unit",
   "tests": [
     {
       "name": "sha256_known_vectors",
-      "description": "Validate SHA256 against implementation-specific test vectors",
+      "description": "Validate SHA256 against NIST known-answer test vectors",
       "test_type": "pure_function_test",
       "input": {
         "function": "sha256",
         "test_cases": [
           {
             "input_string": "",
-            "expected_hash": "64f00588447d0845d68faf4851bb5b1954e1dcfb6f5d3f7dcb43083273f5b614"
+            "expected_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           },
           {
             "input_string": "abc",
-            "expected_hash": "bd706453f1f2dcddc9b6cddbb8f652cd0f69e3209829117cdcaaaae9dcaedc63"
+            "expected_hash": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
           },
           {
             "input_string": "hello world",
-            "expected_hash": "37316a1880dddb4b47973d4b5a58fce38338d70549029567a28767b766908cef"
+            "expected_hash": "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
           }
         ]
       },

--- a/tests/integration/channel_pubsub_tests.c
+++ b/tests/integration/channel_pubsub_tests.c
@@ -1,6 +1,7 @@
 #ifdef BUILD_TESTS
 
 #include "../../merc.h"
+#include "../../wilds.h"
 #include "../../interp.h"
 #include "channel_transport.h"
 #include "channel_service.h"
@@ -481,6 +482,7 @@ static test_result_t test_channel_effective_subscriptions_room_regular(test_case
 static test_result_t test_channel_effective_subscriptions_room_wilds(test_case_t *test)
 {
     AREA_DATA area;
+    WILDS_DATA wilds;
     ROOM_INDEX_DATA room;
     CHAR_DATA actor;
     char out[8192];
@@ -489,14 +491,15 @@ static test_result_t test_channel_effective_subscriptions_room_wilds(test_case_t
     (void)test;
 
     memset(&area, 0, sizeof(area));
+    memset(&wilds, 0, sizeof(wilds));
     memset(&room, 0, sizeof(room));
     memset(&actor, 0, sizeof(actor));
     memset(out, 0, sizeof(out));
 
     area.uid = 9292;
+    wilds.uid = 501;
     room.area = &area;
-    room.wilds = (WILDS_DATA *)1;
-    room.w = 501;
+    room.wilds = &wilds;
     room.x = 77;
     room.y = 88;
 


### PR DESCRIPTION
sha256.c defines SHA256_Init/Update/Final which are the exact same symbols OpenSSL exports. Adding it to the build caused symbol interposition: the MUD's custom (non-standard) SHA256 replaced OpenSSL's own implementation inside libssl, corrupting RSA-PSS signing during TLS handshakes.

Fixes:
- Remove sha256.c from CMakeLists.txt and Makefile
- Restore sha256_crypt() in handler.c using OpenSSL EVP (as it was before the SHA256 unit test PR erroneously added the custom implementation back)
- Update sha256 unit test vectors from custom-implementation-specific values to correct NIST SHA256 known-answer values
- Fix channel_pubsub_tests wilds room test: replace fake (WILDS_DATA*)1 pointer with a real zeroed WILDS_DATA stub so room->wilds->uid does not segfault (consequence of earlier fix to use wilds->uid instead of room->w)