### PR TITLE
fix(gmcp): enable bGMCP for WebSocket, send link data before text

### DIFF
--- a/protocol_websocket.c
+++ b/protocol_websocket.c
@@ -154,6 +154,7 @@ static void process_gmcp_input(protocol_websocket_t *ws_proto, const char *input
             ws_proto->supports_char = true;
             ws_proto->supports_room = true;
             if (ws_proto->base.descriptor && ws_proto->base.descriptor->pProtocol) {
+                ws_proto->base.descriptor->pProtocol->bGMCP = true;
                 ws_proto->base.descriptor->pProtocol->bGMCPSupport[GMCP_SUPPORT_SENTIENCE] = true;
             }
             log_string("WebSocket client supports Sentience.* GMCP packages");
@@ -285,6 +286,7 @@ static void websocket_negotiate(protocol_layer_t *proto)
 
     /* WebSocket clients always get Sentience.* packages */
     if (proto->descriptor && proto->descriptor->pProtocol) {
+        proto->descriptor->pProtocol->bGMCP = true;
         proto->descriptor->pProtocol->bGMCPSupport[GMCP_SUPPORT_SENTIENCE] = true;
     }
 

--- a/sentience_link.c
+++ b/sentience_link.c
@@ -222,13 +222,30 @@ void sentience_link_queue_flush(descriptor_t *d)
     if (queue->count == 0)
         return;
 
-    /* Only send GMCP for WebSocket clients with Sentience support */
+    /* Only send GMCP for WebSocket clients with GMCP support */
     if (is_websocket_connection(d) && d->pProtocol->bGMCP) {
         arr = sentience_link_queue_to_json(queue);
         if (arr) {
             dump = json_dumps(arr, JSON_COMPACT);
             if (dump) {
-                SendGMCPRaw(d, "Sentience.Link.List", dump);
+                /*
+                 * Send GMCP as a separate WebSocket frame BEFORE the text
+                 * frame, so the client has link metadata before it sees
+                 * the OSC 8 markers in the text.  Write directly to the
+                 * socket via connection_write() to avoid mixing with the
+                 * pending text in d->outbuf.
+                 */
+                char *msg;
+                int len;
+                size_t msg_size = strlen("Sentience.Link.List") + 1
+                                + strlen(dump) + 3; /* " \n\r\0" */
+                msg = alloc_mem(msg_size);
+                len = snprintf(msg, msg_size, "Sentience.Link.List %s\n\r", dump);
+                if (len > 0 && d->conn) {
+                    int bytes_written;
+                    connection_write(d->conn, msg, len, &bytes_written);
+                }
+                free_mem(msg, msg_size);
                 free(dump);
             }
             json_decref(arr);


### PR DESCRIPTION
Two issues preventing GMCP delivery to WebSocket clients:

1. WebSocket negotiation set bGMCPSupport[SENTIENCE] but never set bGMCP to true. Both SendGMCPRaw() and sentience_link_queue_flush() gate on bGMCP, so ALL GMCP was silently blocked for WebSocket.

2. Link GMCP (Sentience.Link.List) was routed through write_to_buffer() which appended it AFTER the text in the output buffer. The web client needs link metadata BEFORE the text so it can cross-reference lk_N markers. Now writes directly via connection_write() as a separate WebSocket frame before the text frame is flushed.