### PR TITLE
fix(gmcp): remove trailing \n\r from WebSocket GMCP packages

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -4405,13 +4405,15 @@ void SendGMCPRaw( descriptor_t *apDescriptor, const char *package, const char *j
    /* WebSocket: send as plain text frame (no telnet IAC framing) */
    if ( !descriptor_uses_telnet_iac(apDescriptor) )
    {
-      /* "package json\n\r\0" */
-      size_t need = pkg_len + 1 + json_len + 2 + 1;
+      /* "package json\0" — no trailing \n\r; the web client parses
+       * GMCP lines by package prefix, and a newline here would appear
+       * as a visible blank line in the output stream. */
+      size_t need = pkg_len + 1 + json_len + 1;
       char *buf = alloc_mem(need);
 
       if ( !apDescriptor->fcommand && apDescriptor->pProtocol->WriteOOB <= 0 )
          apDescriptor->pProtocol->WriteOOB = 2;
-      snprintf( buf, need, "%s %s\n\r", package, json_body );
+      snprintf( buf, need, "%s %s", package, json_body );
       write_to_buffer( apDescriptor, buf, 0 );
       free_mem( buf, need );
       return;


### PR DESCRIPTION
WebSocket GMCP packages are in-band text (not IAC-framed like telnet). The trailing \n\r appended by SendGMCPRaw() was being flushed as visible output, causing blank lines every pulse when only GMCP data (like Sentience.Char.Affects) was sent with no player-visible text.

The web client parses GMCP by package prefix — no line terminator needed.